### PR TITLE
Add NativeWrapper receive tests

### DIFF
--- a/reports/report-20250624.md
+++ b/reports/report-20250624.md
@@ -1,0 +1,22 @@
+# Uniswap V4 Periphery Test Report
+
+## Summary
+Executed the full test suite with `forge test`. All existing tests passed. Attempted to generate coverage but the tooling failed to provide results in this environment. Identified lack of tests for `NativeWrapper`'s `receive` function which guards against unexpected ETH sends. Added new test `NativeWrapper.t.sol` covering allowed and disallowed senders.
+
+## Methodology
+- Ran the entire test suite to establish a baseline.
+- Searched the codebase for untested error conditions and found `InvalidEthSender` in `NativeWrapper` had no direct tests.
+- Wrote a minimal harness contract inheriting `NativeWrapper` with public wrappers around `_wrap` and `_unwrap` to trigger ETH receipts from WETH9 and a mock pool manager.
+
+## Test Steps
+- **test_receive_reverts_for_unknown_sender**: Directly sent ETH to the wrapper and expected a revert.
+- **test_receive_from_WETH9_succeeds**: Sent WETH to the wrapper then called `unwrap` to trigger an ETH transfer from WETH9.
+- **test_receive_from_poolManager_succeeds**: Sent ETH via a mock PoolManager contract to verify allowed sender.
+
+## Findings
+- The wrapper correctly reverts when ETH is sent from an arbitrary address.
+- Transfers originating from the configured WETH contract or pool manager succeed.
+- No existing functionality broke; all suites still pass after adding the new tests.
+
+## Conclusion
+The suite remains green and coverage of edge cases in the native wrapper logic has been improved. Coverage tooling was attempted but did not complete, so metrics are unavailable. Further work could integrate coverage generation in CI.

--- a/test/NativeWrapper.t.sol
+++ b/test/NativeWrapper.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {NativeWrapper} from "../src/base/NativeWrapper.sol";
+import {ImmutableState} from "../src/base/ImmutableState.sol";
+import {IWETH9} from "../src/interfaces/external/IWETH9.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+
+contract MockPoolManager {
+    function sendEther(address payable to) external payable {
+        to.transfer(msg.value);
+    }
+}
+
+contract NativeWrapperHarness is NativeWrapper {
+    constructor(IWETH9 _weth9, IPoolManager _poolManager)
+        ImmutableState(_poolManager)
+        NativeWrapper(_weth9)
+    {}
+
+    function wrap(uint256 amount) external payable {
+        _wrap(amount);
+    }
+
+    function unwrap(uint256 amount) external {
+        _unwrap(amount);
+    }
+}
+
+contract NativeWrapperTest is Test {
+    NativeWrapperHarness wrapper;
+    MockPoolManager manager;
+    WETH weth;
+
+    function setUp() public {
+        weth = new WETH();
+        manager = new MockPoolManager();
+        wrapper = new NativeWrapperHarness(IWETH9(address(weth)), IPoolManager(address(manager)));
+    }
+
+    function test_receive_reverts_for_unknown_sender() public {
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert(NativeWrapper.InvalidEthSender.selector);
+        address(wrapper).call{value: 1 ether}("");
+    }
+
+    function test_receive_from_WETH9_succeeds() public {
+        vm.deal(address(this), 1 ether);
+        weth.deposit{value: 1 ether}();
+        weth.transfer(address(wrapper), 1 ether);
+        wrapper.unwrap(1 ether);
+    }
+
+    function test_receive_from_poolManager_succeeds() public {
+        vm.deal(address(manager), 1 ether);
+        manager.sendEther{value: 1 ether}(payable(address(wrapper)));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for NativeWrapper receive function
- document testing process in report

## Testing
- `forge test -vvv --match-contract NativeWrapperTest`
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685b04307778832d977a1e277d5e033b