### PR TITLE
Add tests for DeltaResolver wrap/unwrap mapping

### DIFF
--- a/reports/report-20250624-02.md
+++ b/reports/report-20250624-02.md
@@ -1,0 +1,22 @@
+# DeltaResolver mapping unit tests
+
+## Summary
+This report documents the attempt to run the periphery test suite and to cover under-tested logic in `DeltaResolver`. A new harness was created to expose `_mapWrapUnwrapAmount` which previously lacked direct unit tests.
+
+## Test Methodology
+- Attempted to run `forge test` for both periphery and core. Periphery tests executed successfully but core tests could not finish due to environment time constraints.
+- Coverage generation via `forge coverage` was attempted but terminated early for the same reason.
+- Source inspection highlighted that helper functions in `DeltaResolver` had no dedicated tests. `_mapWrapUnwrapAmount` performs important balance checks when wrapping or unwrapping assets.
+- A minimal `MockPoolManager` implementing the required `exttload` interface was created. A harness contract exposed the internal mapping function.
+
+## Test Steps
+- **test_contractBalance** – verifies that when `CONTRACT_BALANCE` is passed, the function returns the contract’s entire balance.
+- **test_openDeltaUsesDebt** – sets a negative delta on the mock manager and verifies that passing `OPEN_DELTA` maps to the owed amount.
+- **test_revertInsufficientBalance** – ensures the function reverts with `InsufficientBalance` when the amount exceeds the held balance.
+
+## Findings
+- All new tests pass indicating the mapping logic behaves as expected.
+- No flaws were found in `_mapWrapUnwrapAmount`. The tests provide direct coverage of edge cases that were previously untested.
+
+## Conclusion
+The additional tests improve coverage for `DeltaResolver`'s internal helpers. Full coverage and running of the core suite were limited by environment timeouts; future work should include running the core tests and producing coverage metrics in a more capable environment.

--- a/test/DeltaResolverMapWrapUnwrap.t.sol
+++ b/test/DeltaResolverMapWrapUnwrap.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {DeltaResolver} from "../src/base/DeltaResolver.sol";
+import {ImmutableState} from "../src/base/ImmutableState.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {ActionConstants} from "../src/libraries/ActionConstants.sol";
+
+contract MockPoolManager {
+    mapping(bytes32 => int256) public deltas;
+
+    function setDelta(address owner, Currency currency, int256 delta) external {
+        deltas[keccak256(abi.encode(owner, Currency.unwrap(currency)))] = delta;
+    }
+
+    function currencyDelta(address owner, Currency currency) external view returns (int256) {
+        return deltas[keccak256(abi.encode(owner, Currency.unwrap(currency)))];
+    }
+
+    function exttload(bytes32 slot) external view returns (bytes32 value) {
+        return bytes32(uint256(int256(deltas[slot])));
+    }
+
+    function sync(Currency) external {}
+    function settle() external payable {}
+    function take(Currency, address, uint256) external {}
+}
+
+contract MapWrapUnwrapHarness is DeltaResolver {
+    constructor(MockPoolManager _manager) ImmutableState(IPoolManager(address(_manager))) {}
+
+    function expose_mapWrapUnwrapAmount(Currency inputCurrency, uint256 amount, Currency outputCurrency)
+        external
+        view
+        returns (uint256)
+    {
+        return _mapWrapUnwrapAmount(inputCurrency, amount, outputCurrency);
+    }
+
+    function _pay(Currency, address, uint256) internal override {}
+}
+
+contract DeltaResolverMapWrapUnwrapTest is Test {
+    MockPoolManager manager;
+    MapWrapUnwrapHarness harness;
+    MockERC20 token;
+    Currency tokenCurrency;
+
+    function setUp() public {
+        manager = new MockPoolManager();
+        harness = new MapWrapUnwrapHarness(manager);
+        token = new MockERC20("T", "T", 18);
+        tokenCurrency = Currency.wrap(address(token));
+    }
+
+    function test_contractBalance() public {
+        token.mint(address(harness), 20);
+        uint256 amount = harness.expose_mapWrapUnwrapAmount(tokenCurrency, ActionConstants.CONTRACT_BALANCE, tokenCurrency);
+        assertEq(amount, 20);
+    }
+
+    function test_openDeltaUsesDebt() public {
+        manager.setDelta(address(harness), tokenCurrency, -7);
+        token.mint(address(harness), 10);
+        uint256 amount = harness.expose_mapWrapUnwrapAmount(tokenCurrency, ActionConstants.OPEN_DELTA, tokenCurrency);
+        assertEq(amount, 7);
+    }
+
+    function test_revertInsufficientBalance() public {
+        token.mint(address(harness), 5);
+        vm.expectRevert(DeltaResolver.InsufficientBalance.selector);
+        harness.expose_mapWrapUnwrapAmount(tokenCurrency, 10, tokenCurrency);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add targeted tests for `_mapWrapUnwrapAmount` in `DeltaResolver`
- document results in new report

## Testing
- `forge test --match-contract DeltaResolverMapWrapUnwrapTest`

------
https://chatgpt.com/codex/tasks/task_e_685b10c87830832d90f795d805c73300