### PR TITLE
Add tests for payer mapping and permit2 revert handling

### DIFF
--- a/reports/report-permit2-forwarder-20250624.md
+++ b/reports/report-permit2-forwarder-20250624.md
@@ -1,0 +1,20 @@
+# Permit2 Forwarder and Base Router Tests
+
+## Summary
+Added targeted tests for mapping payer address in `BaseActionsRouter` and for handling revert scenarios in `Permit2Forwarder`. A mock `RevertingPermit2` contract simulates failure paths.
+
+## Test Methodology
+- **Map Payer**: Exposed internal `_mapPayer` via `MockBaseActionsRouter` and verified outputs for both user and contract scenarios.
+- **Permit2 Forwarder**: Created `RevertingPermit2` to force `permit` and `permitBatch` calls to revert and checked returned error bytes.
+
+## Test Steps
+- `test_mapPayer` checks address returned when payer is the user vs. the contract.
+- `test_permit_single_returns_error_on_revert` uses the mock to simulate failure of a single permit.
+- `test_permit_batch_returns_error_on_revert` does the same for batch permits.
+
+## Findings
+- Functions behave as expected under both normal and reverting conditions.
+- No unexpected failures observed across the full suite of `519` tests.
+
+## Conclusion
+The added tests cover previously untested branches, ensuring correct payer mapping and robust error handling in permit forwarding.

--- a/test/BaseActionsRouter.t.sol
+++ b/test/BaseActionsRouter.t.sol
@@ -146,4 +146,11 @@ contract BaseActionsRouterTest is Test, Deployers {
             assertEq(mappedRecipient, recipient);
         }
     }
+
+    function test_mapPayer() public view {
+        // when payerIsUser=true should return msgSender()
+        assertEq(router.mapPayer(true), address(0xdeadbeef));
+        // when false should return address(this)
+        assertEq(router.mapPayer(false), address(router));
+    }
 }

--- a/test/mocks/MockBaseActionsRouter.sol
+++ b/test/mocks/MockBaseActionsRouter.sol
@@ -84,4 +84,8 @@ contract MockBaseActionsRouter is BaseActionsRouter, ReentrancyLock {
     function mapRecipient(address recipient) external view returns (address) {
         return _mapRecipient(recipient);
     }
+
+    function mapPayer(bool payerIsUser) external view returns (address) {
+        return _mapPayer(payerIsUser);
+    }
 }

--- a/test/mocks/RevertingPermit2.sol
+++ b/test/mocks/RevertingPermit2.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
+
+contract RevertingPermit2 is IAllowanceTransfer {
+    function DOMAIN_SEPARATOR() external pure returns (bytes32) {
+        return bytes32(0);
+    }
+    function allowance(address, address, address) external pure override returns (uint160, uint48, uint48) {
+        return (0,0,0);
+    }
+    function approve(address, address, uint160, uint48) external pure override {}
+    function permit(address, PermitSingle memory, bytes calldata) external pure override {
+        revert("mock revert");
+    }
+    function permit(address, PermitBatch memory, bytes calldata) external pure override {
+        revert("mock revert");
+    }
+    function transferFrom(address, address, uint160, address) external pure override {}
+    function transferFrom(AllowanceTransferDetails[] calldata) external pure override {}
+    function lockdown(TokenSpenderPair[] calldata) external pure override {}
+    function invalidateNonces(address, address, uint48) external pure override {}
+}

--- a/test/position-managers/Permit2Forwarder.t.sol
+++ b/test/position-managers/Permit2Forwarder.t.sol
@@ -10,6 +10,7 @@ import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol"
 import {PosmTestSetup} from "../shared/PosmTestSetup.sol";
 import {Permit2Forwarder} from "../../src/base/Permit2Forwarder.sol";
 import {Permit2SignatureHelpers} from "../shared/Permit2SignatureHelpers.sol";
+import {RevertingPermit2} from "../mocks/RevertingPermit2.sol";
 
 contract Permit2ForwarderTest is Test, PosmTestSetup, Permit2SignatureHelpers {
     Permit2Forwarder permit2Forwarder;
@@ -71,5 +72,28 @@ contract Permit2ForwarderTest is Test, PosmTestSetup, Permit2SignatureHelpers {
         assertEq(_amount1, amount0);
         assertEq(_expiration1, expiration);
         assertEq(_nonce1, nonce + 1);
+    }
+
+    function test_permit_single_returns_error_on_revert() public {
+        RevertingPermit2 badPermit2 = new RevertingPermit2();
+        Permit2Forwarder forwarder = new Permit2Forwarder(badPermit2);
+        IAllowanceTransfer.PermitSingle memory permit =
+            defaultERC20PermitAllowance(Currency.unwrap(currency0), amount0, expiration, nonce);
+        bytes memory sig = getPermitSignature(permit, alicePrivateKey, PERMIT2_DOMAIN_SEPARATOR);
+        bytes memory err = forwarder.permit(alice, permit, sig);
+        assertEq(err, abi.encodeWithSignature("Error(string)", "mock revert"));
+    }
+
+    function test_permit_batch_returns_error_on_revert() public {
+        RevertingPermit2 badPermit2 = new RevertingPermit2();
+        Permit2Forwarder forwarder = new Permit2Forwarder(badPermit2);
+        address[] memory tokens = new address[](2);
+        tokens[0] = Currency.unwrap(currency0);
+        tokens[1] = Currency.unwrap(currency1);
+        IAllowanceTransfer.PermitBatch memory permit =
+            defaultERC20PermitBatchAllowance(tokens, amount0, expiration, nonce);
+        bytes memory sig = getPermitBatchSignature(permit, alicePrivateKey, PERMIT2_DOMAIN_SEPARATOR);
+        bytes memory err = forwarder.permitBatch(alice, permit, sig);
+        assertEq(err, abi.encodeWithSignature("Error(string)", "mock revert"));
     }
 }


### PR DESCRIPTION
## Summary
- expose `_mapPayer` on `MockBaseActionsRouter`
- cover `_mapPayer` in `BaseActionsRouter.t.sol`
- create `RevertingPermit2` mock and use it for new revert tests
- document the additions in a new report

## Testing
- `forge test -vv`
- `forge test --match-contract Permit2ForwarderTest -vv`

------
https://chatgpt.com/codex/tasks/task_e_685b170c8374832da5d0f4e7e4f5b242