### PR TITLE
Add BaseHook revert tests

### DIFF
--- a/reports/report-basehook-20250624-01.md
+++ b/reports/report-basehook-20250624-01.md
@@ -1,0 +1,21 @@
+# BaseHook Revert Behavior - 2025-06-24
+
+## Summary
+Added targeted tests for the abstract `BaseHook` contract to ensure all unimplemented hook callbacks revert with `HookNotImplemented` and that `onlyPoolManager` access control functions correctly. Prior to this, `BaseHook` had minimal coverage.
+
+## Test Methodology
+- Inspected coverage output (`lcov.info`) and observed `src/utils/BaseHook.sol` had ~22% line coverage.
+- Created a `DummyHook` inheriting `BaseHook` without overriding any hook functions. Overrode `validateHookAddress` to bypass address checks.
+- Deployed `DummyHook` using a `DummyPoolManager` stub so calls could satisfy the `onlyPoolManager` modifier via `vm.prank`.
+
+## Test Steps
+- **test_onlyPoolManager**: call `beforeInitialize` from a non-manager address expecting `ImmutableState.NotPoolManager` revert.
+- **test_allHooksRevert**: from the manager address call every hook callback (`beforeInitialize`, `afterInitialize`, etc.) expecting `HookNotImplemented` revert each time.
+
+## Findings
+- All hook functions correctly reverted with `HookNotImplemented` when called from the pool manager.
+- Calls from other addresses reverted with `NotPoolManager` as intended.
+- The full test suite now runs 518 tests with all passing.
+
+## Conclusion
+The new tests raised coverage of `BaseHook` and verified its default revert logic and access control. No functional issues were discovered. Future work might include further exercising libraries like `SVG.sol` which still show low coverage.

--- a/test/BaseHook.t.sol
+++ b/test/BaseHook.t.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {BaseHook} from "../src/utils/BaseHook.sol";
+import {ImmutableState} from "../src/base/ImmutableState.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {ModifyLiquidityParams, SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+import {BalanceDelta, BalanceDeltaLibrary} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {BeforeSwapDelta} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+
+contract DummyPoolManager {}
+
+contract DummyHook is BaseHook {
+    constructor(IPoolManager manager) BaseHook(manager) {}
+
+    function validateHookAddress(BaseHook) internal pure override {}
+
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory perm) {
+        perm = Hooks.Permissions({
+            beforeInitialize: false,
+            afterInitialize: false,
+            beforeAddLiquidity: false,
+            afterAddLiquidity: false,
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeSwap: false,
+            afterSwap: false,
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: false,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+}
+
+contract BaseHookTest is Test {
+    DummyPoolManager manager;
+    DummyHook hook;
+    PoolKey key;
+    ModifyLiquidityParams modifyParams;
+    SwapParams swapParams;
+
+    function setUp() public {
+        manager = new DummyPoolManager();
+        hook = new DummyHook(IPoolManager(address(manager)));
+
+        key = PoolKey({
+            currency0: Currency.wrap(address(0)),
+            currency1: Currency.wrap(address(1)),
+            fee: 3000,
+            tickSpacing: 1,
+            hooks: IHooks(address(0))
+        });
+
+        modifyParams = ModifyLiquidityParams({tickLower: -10, tickUpper: 10, liquidityDelta: 1, salt: bytes32(0)});
+        swapParams = SwapParams({zeroForOne: true, amountSpecified: 1, sqrtPriceLimitX96: 0});
+    }
+
+    function test_onlyPoolManager() public {
+        vm.expectRevert(ImmutableState.NotPoolManager.selector);
+        hook.beforeInitialize(address(this), key, 0);
+    }
+
+    function test_allHooksRevert() public {
+        vm.startPrank(address(manager));
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.beforeInitialize(address(this), key, 0);
+
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.afterInitialize(address(this), key, 0, 0);
+
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.beforeAddLiquidity(address(this), key, modifyParams, "");
+
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.beforeRemoveLiquidity(address(this), key, modifyParams, "");
+
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.afterAddLiquidity(address(this), key, modifyParams, BalanceDeltaLibrary.ZERO_DELTA, BalanceDeltaLibrary.ZERO_DELTA, "");
+
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.afterRemoveLiquidity(address(this), key, modifyParams, BalanceDeltaLibrary.ZERO_DELTA, BalanceDeltaLibrary.ZERO_DELTA, "");
+
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.beforeSwap(address(this), key, swapParams, "");
+
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.afterSwap(address(this), key, swapParams, BalanceDeltaLibrary.ZERO_DELTA, "");
+
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.beforeDonate(address(this), key, 0, 0, "");
+
+        vm.expectRevert(BaseHook.HookNotImplemented.selector);
+        hook.afterDonate(address(this), key, 0, 0, "");
+        vm.stopPrank();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests for BaseHook default revert paths and onlyPoolManager access check
- document coverage improvement in new report

## Testing
- `forge test -vvv --match-contract BaseHookTest`
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685b170c8374832da5d0f4e7e4f5b242