### PR TITLE
Add DeltaResolver mapping tests

### DIFF
--- a/reports/report-DeltaResolverSettleTake-20250624-2134.md
+++ b/reports/report-DeltaResolverSettleTake-20250624-2134.md
@@ -1,0 +1,23 @@
+# DeltaResolver mapping tests
+
+## Summary
+This report documents targeted tests for the mapping helpers in `DeltaResolver`. Existing coverage did not exercise `_mapSettleAmount` and `_mapTakeAmount`, leaving edge cases around OPEN_DELTA and CONTRACT_BALANCE unchecked. A new test suite was added and all tests continue to pass.
+
+## Test Methodology
+- Scanned the repository for functions without dedicated tests. `_mapSettleAmount` and `_mapTakeAmount` were not referenced in any suite.
+- Created a minimal harness exposing these internal functions and a mock PoolManager with transient state support.
+- Designed deterministic tests around debt/credit scenarios and expected revert conditions.
+
+## Test Steps
+- **test_settle_contractBalance**: verifies `_mapSettleAmount` returns the contract balance when passed `CONTRACT_BALANCE`.
+- **test_settle_openDelta_usesDebt**: ensures OPEN_DELTA pulls the full debt amount.
+- **test_settle_openDelta_revertsOnPositiveDelta**: checks that a positive delta causes `DeltaNotNegative` to revert.
+- **test_take_openDelta_usesCredit**: confirms OPEN_DELTA fetches the full credit amount.
+- **test_take_openDelta_revertsOnNegativeDelta**: validates that a negative delta triggers `DeltaNotPositive`.
+
+## Findings
+- All five new tests passed alongside the existing suite, resulting in 521 successful tests in total.
+- The added suite covers previously untested branches of `DeltaResolver` and demonstrated correct revert behaviour.
+
+## Conclusion
+The new tests strengthen confidence in the settling and taking helpers without uncovering defects. Future efforts might expand coverage for other internal helpers or integrate coverage reporting into CI for a clearer view of remaining gaps.

--- a/test/DeltaResolverMapSettleTake.t.sol
+++ b/test/DeltaResolverMapSettleTake.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {DeltaResolver} from "../src/base/DeltaResolver.sol";
+import {ImmutableState} from "../src/base/ImmutableState.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {ActionConstants} from "../src/libraries/ActionConstants.sol";
+
+contract MockPoolManagerDR {
+    mapping(bytes32 => int256) public deltas;
+
+    function setDelta(address owner, Currency currency, int256 delta) external {
+        deltas[keccak256(abi.encode(owner, Currency.unwrap(currency)))] = delta;
+    }
+
+    function currencyDelta(address owner, Currency currency) external view returns (int256) {
+        return deltas[keccak256(abi.encode(owner, Currency.unwrap(currency)))];
+    }
+
+    function exttload(bytes32 slot) external view returns (bytes32 value) {
+        return bytes32(uint256(int256(deltas[slot])));
+    }
+
+    function sync(Currency) external {}
+    function settle() external payable {}
+    function take(Currency, address, uint256) external {}
+}
+
+contract MapSettleTakeHarness is DeltaResolver {
+    constructor(MockPoolManagerDR manager) ImmutableState(IPoolManager(address(manager))) {}
+
+    function expose_mapSettleAmount(Currency currency, uint256 amount) external view returns (uint256) {
+        return _mapSettleAmount(amount, currency);
+    }
+
+    function expose_mapTakeAmount(Currency currency, uint256 amount) external view returns (uint256) {
+        return _mapTakeAmount(amount, currency);
+    }
+
+    function _pay(Currency, address, uint256) internal override {}
+}
+
+contract DeltaResolverMapSettleTakeTest is Test {
+    MockPoolManagerDR manager;
+    MapSettleTakeHarness harness;
+    MockERC20 token;
+    Currency tokenCurrency;
+
+    function setUp() public {
+        manager = new MockPoolManagerDR();
+        harness = new MapSettleTakeHarness(manager);
+        token = new MockERC20("T", "T", 18);
+        tokenCurrency = Currency.wrap(address(token));
+    }
+
+    function test_settle_contractBalance() public {
+        token.mint(address(harness), 15);
+        uint256 amount = harness.expose_mapSettleAmount(tokenCurrency, ActionConstants.CONTRACT_BALANCE);
+        assertEq(amount, 15);
+    }
+
+    function test_settle_openDelta_usesDebt() public {
+        manager.setDelta(address(harness), tokenCurrency, -8);
+        uint256 amount = harness.expose_mapSettleAmount(tokenCurrency, ActionConstants.OPEN_DELTA);
+        assertEq(amount, 8);
+    }
+
+    function test_settle_openDelta_revertsOnPositiveDelta() public {
+        manager.setDelta(address(harness), tokenCurrency, 4);
+        vm.expectRevert(abi.encodeWithSelector(DeltaResolver.DeltaNotNegative.selector, tokenCurrency));
+        harness.expose_mapSettleAmount(tokenCurrency, ActionConstants.OPEN_DELTA);
+    }
+
+    function test_take_openDelta_usesCredit() public {
+        manager.setDelta(address(harness), tokenCurrency, 9);
+        uint256 amount = harness.expose_mapTakeAmount(tokenCurrency, ActionConstants.OPEN_DELTA);
+        assertEq(amount, 9);
+    }
+
+    function test_take_openDelta_revertsOnNegativeDelta() public {
+        manager.setDelta(address(harness), tokenCurrency, -2);
+        vm.expectRevert(abi.encodeWithSelector(DeltaResolver.DeltaNotPositive.selector, tokenCurrency));
+        harness.expose_mapTakeAmount(tokenCurrency, ActionConstants.OPEN_DELTA);
+    }
+}
+


### PR DESCRIPTION
## Summary
- run all forge tests
- add unit tests for `_mapSettleAmount` and `_mapTakeAmount`
- document results in a new report

## Testing
- `forge test`
- `forge test --match-path test/DeltaResolverMapSettleTake.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_685b170c8374832da5d0f4e7e4f5b242