### PR TITLE
Add tests for SafeCurrencyMetadata edge cases

### DIFF
--- a/reports/report-SafeCurrencyMetadata-20250624-03.md
+++ b/reports/report-SafeCurrencyMetadata-20250624-03.md
@@ -1,0 +1,27 @@
+# SafeCurrencyMetadata additional tests report
+
+## Summary
+This report records the creation of new unit tests for `SafeCurrencyMetadata` in the periphery repository. The goal was to cover missing cases around handling of token metadata, specifically when tokens lack symbol/decimals or return unusual values. All tests pass.
+
+## Test Methodology
+- Identified that only `truncateSymbol` was tested previously.
+- Created minimal mock contracts for tokens with no symbol, bytes32 symbol, overly long symbol, and invalid decimals.
+- Added tests exercising `currencySymbol` and `currencyDecimals` for native currency and these mock tokens.
+
+## Test Steps
+- Added `MockNoSymbol`, `MockBytes32Symbol`, `MockLongSymbol`, and `MockBadDecimals` in `test/libraries`.
+- Expanded `SafeCurrencyMetadata.t.sol` with six new tests:
+  - `test_currencySymbol_native`
+  - `test_currencySymbol_noSymbol`
+  - `test_currencySymbol_bytes32`
+  - `test_currencySymbol_longString_truncated`
+  - `test_currencyDecimals_native`
+  - `test_currencyDecimals_bad`
+- Verified compilation and ran the full test suite via `forge test`.
+
+## Findings
+- All new tests passed, confirming expected behaviour when tokens provide unusual metadata or none at all.
+- No flaws discovered in library logic; behaviour matched specification.
+
+## Conclusion
+The added tests increase coverage for `SafeCurrencyMetadata` by verifying behaviour for edge cases. No issues were found, but the added assertions strengthen confidence in metadata handling.

--- a/test/libraries/MockBadDecimals.sol
+++ b/test/libraries/MockBadDecimals.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract MockBadDecimals {
+    function decimals() external pure returns (uint256) {
+        return 300;
+    }
+}

--- a/test/libraries/MockBytes32Symbol.sol
+++ b/test/libraries/MockBytes32Symbol.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract MockBytes32Symbol {
+    function symbol() external pure returns (bytes32) {
+        return bytes32("BYTES32SYM");
+    }
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+}

--- a/test/libraries/MockLongSymbol.sol
+++ b/test/libraries/MockLongSymbol.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract MockLongSymbol {
+    function symbol() external pure returns (string memory) {
+        return "ABCDEFGHIJKLM"; // 13 chars
+    }
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+}

--- a/test/libraries/MockNoSymbol.sol
+++ b/test/libraries/MockNoSymbol.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract MockNoSymbol {
+    // no symbol or decimals functions
+}

--- a/test/libraries/SafeCurrencyMetadata.t.sol
+++ b/test/libraries/SafeCurrencyMetadata.t.sol
@@ -3,6 +3,11 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 import {SafeCurrencyMetadata} from "../../src/libraries/SafeCurrencyMetadata.sol";
+import {MockNoSymbol} from "./MockNoSymbol.sol";
+import {MockBytes32Symbol} from "./MockBytes32Symbol.sol";
+import {MockLongSymbol} from "./MockLongSymbol.sol";
+import {MockBadDecimals} from "./MockBadDecimals.sol";
+import {AddressStringUtil} from "../../src/libraries/AddressStringUtil.sol";
 
 contract SafeCurrencyMetadataTest is Test {
     function test_truncateSymbol_succeeds() public pure {
@@ -12,5 +17,34 @@ contract SafeCurrencyMetadataTest is Test {
         assertEq(SafeCurrencyMetadata.truncateSymbol("1234567890123"), "123456789012");
         // 14 characters
         assertEq(SafeCurrencyMetadata.truncateSymbol("12345678901234"), "123456789012");
+    }
+
+    function test_currencySymbol_native() public view {
+        assertEq(SafeCurrencyMetadata.currencySymbol(address(0), "ETH"), "ETH");
+    }
+
+    function test_currencySymbol_noSymbol() public {
+        MockNoSymbol token = new MockNoSymbol();
+        string memory expected = AddressStringUtil.toAsciiString(address(token), 6);
+        assertEq(SafeCurrencyMetadata.currencySymbol(address(token), "NATIVE"), expected);
+    }
+
+    function test_currencySymbol_bytes32() public {
+        MockBytes32Symbol token = new MockBytes32Symbol();
+        assertEq(SafeCurrencyMetadata.currencySymbol(address(token), ""), "BYTES32SYM");
+    }
+
+    function test_currencySymbol_longString_truncated() public {
+        MockLongSymbol token = new MockLongSymbol();
+        assertEq(SafeCurrencyMetadata.currencySymbol(address(token), ""), "ABCDEFGHIJKL");
+    }
+
+    function test_currencyDecimals_native() public view {
+        assertEq(SafeCurrencyMetadata.currencyDecimals(address(0)), 18);
+    }
+
+    function test_currencyDecimals_bad() public {
+        MockBadDecimals token = new MockBadDecimals();
+        assertEq(SafeCurrencyMetadata.currencyDecimals(address(token)), 0);
     }
 }


### PR DESCRIPTION
## Summary
- extend SafeCurrencyMetadata tests for native currency and tokens without metadata
- add small mock contracts for special metadata cases
- document the additions in a new report

## Testing
- `forge test --match-path test/libraries/SafeCurrencyMetadata.t.sol -vv`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685b1ec0c7a0832d8f137c684c386d11