### PR TITLE
Add tests for helper libraries

### DIFF
--- a/reports/report-quoter-safecurrency-20250624-03.md
+++ b/reports/report-quoter-safecurrency-20250624-03.md
@@ -1,0 +1,22 @@
+# Library Gap Tests - 20250624
+
+## Summary
+Added targeted unit tests for previously under-tested helper libraries including `QuoterRevert`, `SafeCurrencyMetadata`, and `SlippageCheck`. All baseline tests continue to pass and coverage improved slightly.
+
+## Test Methodology
+- Identified low coverage libraries from `forge coverage` (`QuoterRevert`, `SafeCurrencyMetadata`, `SlippageCheck`).
+- Crafted minimal harness contracts to call library functions and observe revert behaviour.
+- Extended existing SafeCurrencyMetadata tests with ERC20 mocks to exercise edge cases in symbol and decimals handling.
+- Executed the full suite with `forge test` and generated updated coverage metrics.
+
+## Test Steps
+- **QuoterRevertTest**: verified `revertQuote` and `parseQuoteAmount` round‑trip and that invalid selectors revert via `UnexpectedRevertBytes`.
+- **SafeCurrencyMetadataExtraTest**: mocked tokens to check symbol fallback, truncation, standard decimals, overflow, and revert cases.
+- **SlippageCheckTest**: used a harness to ensure positive deltas pass and invalid deltas revert.
+
+## Findings
+- All new tests succeeded; `forge test` reports `539` passing tests with no failures.
+- Coverage summary shows overall line coverage around `74%` with improvements in the targeted files.
+
+## Conclusion
+The additional tests strengthen assurances around error handling and edge cases in auxiliary libraries. No defects were uncovered.

--- a/test/libraries/QuoterRevert.t.sol
+++ b/test/libraries/QuoterRevert.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {QuoterRevert} from "../../src/libraries/QuoterRevert.sol";
+
+contract QuoterRevertWrapper {
+    function callRevertQuote(uint256 amount) external pure {
+        QuoterRevert.revertQuote(amount);
+    }
+
+    function callBubble(bytes calldata data) external pure {
+        QuoterRevert.bubbleReason(data);
+    }
+
+    function callParse(bytes calldata data) external pure returns (uint256) {
+        return QuoterRevert.parseQuoteAmount(data);
+    }
+}
+
+contract QuoterRevertTest is Test {
+    QuoterRevertWrapper wrapper;
+
+    function setUp() public {
+        wrapper = new QuoterRevertWrapper();
+    }
+
+    function test_revertQuote_and_parse() public {
+        uint256 amount = 123;
+        bytes memory revertData = abi.encodeWithSelector(QuoterRevert.QuoteSwap.selector, amount);
+        vm.expectRevert(revertData);
+        wrapper.callRevertQuote(amount);
+
+        uint256 parsed = wrapper.callParse(revertData);
+        assertEq(parsed, amount);
+    }
+
+    function test_parseQuoteAmount_invalid_selector() public {
+        bytes memory data = abi.encodeWithSelector(bytes4(0xdeadbeef), uint256(1));
+        vm.expectRevert(abi.encodeWithSelector(QuoterRevert.UnexpectedRevertBytes.selector, data));
+        wrapper.callParse(data);
+    }
+
+    function test_bubbleReason() public {
+        bytes memory data = hex"11223344";
+        vm.expectRevert(data);
+        wrapper.callBubble(data);
+    }
+}
+

--- a/test/libraries/SafeCurrencyMetadata.t.sol
+++ b/test/libraries/SafeCurrencyMetadata.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 import {SafeCurrencyMetadata} from "../../src/libraries/SafeCurrencyMetadata.sol";
+import {AddressStringUtil} from "../../src/libraries/AddressStringUtil.sol";
 
 contract SafeCurrencyMetadataTest is Test {
     function test_truncateSymbol_succeeds() public pure {
@@ -12,5 +13,55 @@ contract SafeCurrencyMetadataTest is Test {
         assertEq(SafeCurrencyMetadata.truncateSymbol("1234567890123"), "123456789012");
         // 14 characters
         assertEq(SafeCurrencyMetadata.truncateSymbol("12345678901234"), "123456789012");
+    }
+}
+
+contract MockToken {
+    string public symbolReturn;
+    uint256 public decimalsReturn;
+    bool public revertSymbol;
+    bool public revertDecimals;
+    constructor(string memory s, uint256 d, bool rS, bool rD) {
+        symbolReturn = s;
+        decimalsReturn = d;
+        revertSymbol = rS;
+        revertDecimals = rD;
+    }
+    function symbol() external view returns (string memory) {
+        if (revertSymbol) revert();
+        return symbolReturn;
+    }
+    function decimals() external view returns (uint256) {
+        if (revertDecimals) revert();
+        return decimalsReturn;
+    }
+}
+
+contract SafeCurrencyMetadataExtraTest is Test {
+
+    function test_currencySymbol_fallback() public {
+        MockToken t = new MockToken("", 18, true, false);
+        string memory expected = AddressStringUtil.toAsciiString(address(t), 6);
+        assertEq(SafeCurrencyMetadata.currencySymbol(address(t), "N"), expected);
+    }
+
+    function test_currencySymbol_truncate() public {
+        MockToken t = new MockToken("ABCDEFGHIJKLMNO", 18, false, false);
+        assertEq(SafeCurrencyMetadata.currencySymbol(address(t), "N"), "ABCDEFGHIJKL");
+    }
+
+    function test_currencyDecimals_standard() public {
+        MockToken t = new MockToken("ABC", 18, false, false);
+        assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 18);
+    }
+
+    function test_currencyDecimals_overflow() public {
+        MockToken t = new MockToken("ABC", 300, false, false);
+        assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 0);
+    }
+
+    function test_currencyDecimals_revert() public {
+        MockToken t = new MockToken("ABC", 18, false, true);
+        assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 0);
     }
 }

--- a/test/libraries/SlippageCheck.t.sol
+++ b/test/libraries/SlippageCheck.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {SlippageCheck} from "../../src/libraries/SlippageCheck.sol";
+import {BalanceDelta, toBalanceDelta} from "../../lib/v4-core/src/types/BalanceDelta.sol";
+import {SafeCast} from "../../lib/v4-core/src/libraries/SafeCast.sol";
+
+contract SlippageHarness {
+    function callValidateMaxIn(BalanceDelta delta, uint128 max0, uint128 max1) external pure {
+        SlippageCheck.validateMaxIn(delta, max0, max1);
+    }
+    function callValidateMinOut(BalanceDelta delta, uint128 min0, uint128 min1) external pure {
+        SlippageCheck.validateMinOut(delta, min0, min1);
+    }
+}
+
+contract SlippageCheckTest is Test {
+    SlippageHarness harness;
+
+    function setUp() public {
+        harness = new SlippageHarness();
+    }
+
+    function test_validateMaxIn_positiveDelta() public {
+        BalanceDelta delta = toBalanceDelta(5, 3);
+        harness.callValidateMaxIn(delta, 1, 1);
+    }
+
+    function test_validateMaxIn_exceeds() public {
+        BalanceDelta delta = toBalanceDelta(-6, 0);
+        vm.expectRevert();
+        harness.callValidateMaxIn(delta, 5, 100);
+    }
+
+    function test_validateMinOut_negativeDelta_overflow() public {
+        BalanceDelta delta = toBalanceDelta(-1, 0);
+        vm.expectRevert();
+        harness.callValidateMinOut(delta, 1, 0);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add coverage for QuoterRevert library
- extend SafeCurrencyMetadata tests to exercise edge cases
- introduce SlippageCheck harness tests
- document results in a new report

## Testing
- `forge test`
- `forge coverage`

------
https://chatgpt.com/codex/tasks/task_e_685b1ec0c7a0832d8f137c684c386d11