### PR TITLE
Add targeted SVG and native metadata tests

### DIFF
--- a/reports/report-svg-metadata-20250624-01.md
+++ b/reports/report-svg-metadata-20250624-01.md
@@ -1,0 +1,21 @@
+# SVG and Currency Metadata Coverage
+
+## Summary
+Added targeted tests for SVG helper functions and native currency metadata to increase coverage of libraries.
+
+## Test Methodology
+- Verified curve selection logic in `SVG.getCurve` across range boundaries.
+- Checked circle generation for in-range, under-range and over-range cases in `SVG.generateSVGCurveCircle`.
+- Confirmed `currencySymbol` and `currencyDecimals` return expected values when given the zero address to represent native currency.
+
+## Test Steps
+- Created new test cases in `test/libraries/SVG.t.sol` to assert expected curve strings and circle SVG outputs.
+- Extended `test/libraries/SafeCurrencyMetadata.t.sol` with native currency symbol and decimals checks.
+- Executed `forge test` ensuring all suites pass.
+
+## Findings
+- All new assertions passed; no bugs observed in the targeted functions.
+- Total test count increased from 550 to 554.
+
+## Conclusion
+The additional tests improve coverage for SVG utilities and currency metadata handling. No issues were discovered, indicating existing implementations behave as expected.

--- a/test/libraries/SVG.t.sol
+++ b/test/libraries/SVG.t.sol
@@ -54,4 +54,41 @@ contract DescriptorTest is Test {
         result = SVG.substring("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 39, 42);
         assertEq(result, "Cc2");
     }
+
+    function test_getCurve_boundaries() public pure {
+        assertEq(SVG.getCurve(0, 4, 1), "M1 1C41 41 105 105 145 145");
+        assertEq(SVG.getCurve(0, 8, 1), "M1 1C33 49 97 113 145 145");
+        assertEq(SVG.getCurve(0, 16, 1), "M1 1C33 57 89 113 145 145");
+        assertEq(SVG.getCurve(0, 32, 1), "M1 1C25 65 81 121 145 145");
+        assertEq(SVG.getCurve(0, 64, 1), "M1 1C17 73 73 129 145 145");
+        assertEq(SVG.getCurve(0, 128, 1), "M1 1C9 81 65 137 145 145");
+        assertEq(SVG.getCurve(0, 256, 1), "M1 1C1 89 57.5 145 145 145");
+        assertEq(SVG.getCurve(0, 300, 1), "M1 1C1 97 49 145 145 145");
+    }
+
+    function test_generateSVGCurveCircle_variants() public pure {
+        string memory expectedInRange = string(
+            abi.encodePacked(
+                '<circle cx="73px" cy="190px" r="4px" fill="white" />',
+                '<circle cx="217px" cy="334px" r="4px" fill="white" />'
+            )
+        );
+        assertEq(SVG.generateSVGCurveCircle(0), expectedInRange);
+
+        string memory expectedUnder = string(
+            abi.encodePacked(
+                '<circle cx="73px" cy="190px" r="4px" fill="white" />',
+                '<circle cx="73px" cy="190px" r="24px" fill="none" stroke="white" />'
+            )
+        );
+        assertEq(SVG.generateSVGCurveCircle(-1), expectedUnder);
+
+        string memory expectedOver = string(
+            abi.encodePacked(
+                '<circle cx="217px" cy="334px" r="4px" fill="white" />',
+                '<circle cx="217px" cy="334px" r="24px" fill="none" stroke="white" />'
+            )
+        );
+        assertEq(SVG.generateSVGCurveCircle(1), expectedOver);
+    }
 }

--- a/test/libraries/SafeCurrencyMetadata.t.sol
+++ b/test/libraries/SafeCurrencyMetadata.t.sol
@@ -65,4 +65,12 @@ contract SafeCurrencyMetadataExtraTest is Test {
         MockToken t = new MockToken("ABC", 18, false, true);
         assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 0);
     }
+
+    function test_currencySymbol_native() public {
+        assertEq(SafeCurrencyMetadata.currencySymbol(address(0), "ETH"), "ETH");
+    }
+
+    function test_currencyDecimals_native() public {
+        assertEq(SafeCurrencyMetadata.currencyDecimals(address(0)), 18);
+    }
 }


### PR DESCRIPTION
## Summary
- add unit tests for `SVG` curve helpers
- add native currency checks in `SafeCurrencyMetadata`
- document results in a new report

## Testing
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685b2aab8540832da8f9db74f5f19b42