### PR TITLE
Add BaseActionsRouter revert tests

### DIFF
--- a/reports/report-BaseActionsRouterReverts-20250624.md
+++ b/reports/report-BaseActionsRouterReverts-20250624.md
@@ -1,0 +1,18 @@
+# BaseActionsRouter Revert Scenarios
+
+## Summary
+This report documents additional tests covering failure cases in `BaseActionsRouter`. The goal was to ensure that improper action arrays and unsupported action identifiers revert as expected.
+
+## Test Methodology
+- **Input length mismatch**: executed actions with one entry but zero parameter arrays to confirm `InputLengthMismatch` is triggered.
+- **Unsupported action**: passed an undefined action id (`0xff`) to ensure the router reverts with `UnsupportedAction`.
+
+## Test Steps
+- Constructed raw actions and params arrays using `abi.encode` and `Planner` helper.
+- Used `vm.expectRevert` with the proper error selectors before calling `executeActions`.
+
+## Findings
+- Both new tests pass, confirming the router validates input lengths and action ids.
+
+## Conclusion
+These tests close coverage gaps in the router's error handling. No new flaws were identified.

--- a/test/BaseActionsRouter.t.sol
+++ b/test/BaseActionsRouter.t.sol
@@ -5,6 +5,7 @@ import {MockBaseActionsRouter} from "./mocks/MockBaseActionsRouter.sol";
 import {Planner, Plan} from "./shared/Planner.sol";
 import {Actions} from "../src/libraries/Actions.sol";
 import {ActionConstants} from "../src/libraries/ActionConstants.sol";
+import {BaseActionsRouter} from "../src/base/BaseActionsRouter.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {Test} from "forge-std/Test.sol";
 import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
@@ -152,5 +153,23 @@ contract BaseActionsRouterTest is Test, Deployers {
         assertEq(router.mapPayer(true), address(0xdeadbeef));
         // when false should return address(this)
         assertEq(router.mapPayer(false), address(router));
+    }
+
+    function test_executeActions_inputLengthMismatch_reverts() public {
+        bytes memory actions = hex"01"; // one DECREASE_LIQUIDITY action
+        bytes[] memory params = new bytes[](0); // no params
+
+        bytes memory data = abi.encode(actions, params);
+
+        vm.expectRevert(BaseActionsRouter.InputLengthMismatch.selector);
+        router.executeActions(data);
+    }
+
+    function test_executeActions_unsupportedAction_reverts() public {
+        Plan memory plan = Planner.init();
+        plan.add(0xff, ""); // invalid action id
+
+        vm.expectRevert(abi.encodeWithSelector(BaseActionsRouter.UnsupportedAction.selector, uint256(0xff)));
+        router.executeActions(plan.encode());
     }
 }


### PR DESCRIPTION
## Summary
- add tests for BaseActionsRouter revert scenarios
- document the new tests

## Testing
- `forge test -vvv test/BaseActionsRouter.t.sol`

------
https://chatgpt.com/codex/tasks/task_e_685b2e9a3ac4832db8c868a5c6cc962e