### PR TITLE
Add tests for AddressStringUtil edge cases

### DIFF
--- a/reports/report-addressstringutil-20250624-2324.md
+++ b/reports/report-addressstringutil-20250624-2324.md
@@ -1,0 +1,19 @@
+# AddressStringUtil coverage tests
+
+## Summary
+Added targeted tests for the `AddressStringUtil` library to increase coverage of input validation and truncated outputs. The new tests ensure zero length reverts and confirm correct hexadecimal output when requesting fewer than 20 address bytes.
+
+## Test Methodology
+- Examined coverage output from `forge coverage` and noted `AddressStringUtil.sol` had only ~56% line coverage.
+- Existing tests covered full length conversion and one invalid length path. Missing cases were zero length validation and partial output handling.
+
+## Test Steps
+- **test_invalid_length_zero**: calls `toAsciiString` with length `0` and expects `InvalidAddressLength` revert.
+- **test_toAsciiString_truncated**: converts a test address requesting 3 bytes (length 6) and checks each generated character against expected hexadecimal digits.
+
+## Findings
+- The library correctly rejects a zero length request.
+- Truncated output matches expected hex digits for the most significant bytes.
+
+## Conclusion
+The additional tests raise line and branch coverage for `AddressStringUtil.sol` and verify edge behavior not previously asserted. No issues were uncovered.

--- a/test/libraries/PositionConfigLibrary.t.sol
+++ b/test/libraries/PositionConfigLibrary.t.sol
@@ -124,4 +124,23 @@ contract AddressStringUtilTest is Test {
             assertEq(b[2 * i + 1], charRef(byteVal & 0xf));
         }
     }
+
+    function test_invalid_length_zero() public {
+        vm.expectRevert(abi.encodeWithSelector(AddressStringUtil.InvalidAddressLength.selector, 0));
+        this._call(address(0), 0);
+    }
+
+    function test_toAsciiString_truncated() public {
+        address addr = 0x1234567890AbcdEF1234567890aBcdef12345678;
+        string memory s = AddressStringUtil.toAsciiString(addr, 6);
+        bytes memory b = bytes(s);
+        assertEq(b.length, 6);
+
+        uint256 num = uint256(uint160(addr));
+        for (uint256 i = 0; i < 3; i++) {
+            uint8 byteVal = uint8(num >> (8 * (19 - i)));
+            assertEq(b[2 * i], charRef(byteVal >> 4));
+            assertEq(b[2 * i + 1], charRef(byteVal & 0xf));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add tests for zero length and truncated address output
- document new coverage in report

## Testing
- `forge test`
- `forge coverage --report summary`

------
https://chatgpt.com/codex/tasks/task_e_685b2e9a3ac4832db8c868a5c6cc962e