### PR TITLE
Add PoolInitializer tests

### DIFF
--- a/reports/report-PoolInitializer-20250624-01.md
+++ b/reports/report-PoolInitializer-20250624-01.md
@@ -1,0 +1,18 @@
+# PoolInitializer_v4 edge cases
+
+This report documents coverage gaps for `PoolInitializer_v4` and the newly added tests.
+
+## Test Methodology
+- `initializePool` was previously untested. A mock `PoolManager` was built that records the input price and optionally reverts.
+- A harness contract inheriting `PoolInitializer_v4` exposes the `initializePool` call for testing.
+
+## Test Steps
+- **test_initialize_returns_tick**: deploy harness with a mock manager returning tick `5`. Call `initializePool` and assert the tick and passed price.
+- **test_initialize_returns_max_on_revert**: deploy harness with a mock manager that reverts in `initialize`. Ensure the call returns `type(int24).max`.
+
+## Findings
+- The function correctly forwards parameters and propagates successful ticks.
+- On initialization failure, the function returns the sentinel value as designed.
+
+## Conclusion
+Adding targeted tests increased coverage for the previously untested `PoolInitializer_v4`. No issues were found.

--- a/test/PoolInitializer.t.sol
+++ b/test/PoolInitializer.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+import {PoolInitializer_v4} from "../src/base/PoolInitializer_v4.sol";
+import {ImmutableState} from "../src/base/ImmutableState.sol";
+
+contract MockPoolManagerInit {
+    int24 public returnedTick;
+    bool public shouldRevert;
+    uint160 public lastPrice;
+
+    constructor(int24 _tick, bool _shouldRevert) {
+        returnedTick = _tick;
+        shouldRevert = _shouldRevert;
+    }
+
+    function initialize(PoolKey memory, uint160 sqrtPriceX96) external returns (int24) {
+        lastPrice = sqrtPriceX96;
+        if (shouldRevert) revert("init fail");
+        return returnedTick;
+    }
+}
+
+contract PoolInitializerHarness is PoolInitializer_v4 {
+    constructor(IPoolManager _pm) ImmutableState(_pm) {}
+}
+
+contract PoolInitializerTest is Test {
+    PoolInitializerHarness harness;
+    MockPoolManagerInit manager;
+    PoolKey key;
+
+    function setUp() public {
+        manager = new MockPoolManagerInit(5, false);
+        harness = new PoolInitializerHarness(IPoolManager(address(manager)));
+        key = PoolKey({currency0: Currency.wrap(address(1)), currency1: Currency.wrap(address(2)), fee: 0, tickSpacing: 1, hooks: IHooks(address(0))});
+    }
+
+    function test_initialize_returns_tick() public {
+        int24 tick = harness.initializePool(key, 123);
+        assertEq(tick, 5);
+        assertEq(manager.lastPrice(), 123);
+    }
+
+    function test_initialize_returns_max_on_revert() public {
+        MockPoolManagerInit bad = new MockPoolManagerInit(0, true);
+        PoolInitializerHarness h2 = new PoolInitializerHarness(IPoolManager(address(bad)));
+        int24 tick = h2.initializePool(key, 99);
+        assertEq(tick, type(int24).max);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for PoolInitializer_v4 behavior
- document coverage investigation of PoolInitializer_v4

## Testing
- `forge test --match-test initialize_returns_tick`
- `forge test --match-test initialize_returns_max_on_revert`
- `forge test -vv`
- `forge coverage --report summary --match-test initialize_returns_tick`

------
https://chatgpt.com/codex/tasks/task_e_685b2e9a3ac4832db8c868a5c6cc962e