### PR TITLE
Add test for missing notifyTransfer callback

### DIFF
--- a/reports/report-20250624-2330-missing-notifyTransfer.md
+++ b/reports/report-20250624-2330-missing-notifyTransfer.md
@@ -1,0 +1,24 @@
+# Missing `notifyTransfer` Callback in PositionManager
+
+## Summary
+Tests show that transferring a position NFT does not trigger a `notifyTransfer` call on subscribers. The `PositionManager` simply unsubscribes the position without informing the subscriber of the new owner.
+
+## Methodology
+- Reviewed the `Notifier` contract which claims to send updates "about position modifications or transfers."【F:src/base/Notifier.sol†L10-L11】
+- Inspected `PositionManager.transferFrom` which merely calls `_unsubscribe` after transferring the token.【F:src/PositionManager.sol†L534-L538】
+- Noted that the current `ISubscriber` interface lacks any `notifyTransfer` function.【F:src/interfaces/ISubscriber.sol†L7-L38】
+- Created `MockTransferSubscriber` implementing `notifyTransfer` to detect callbacks.
+- Wrote `NotifyTransferTest` which subscribes a position, transfers it, and checks that `notifyTransfer` was never called.
+
+## Findings
+```
+[PASS] test_safeTransfer_doesNotNotifyTransfer() (gas: 515506)
+[PASS] test_transferFrom_doesNotNotifyTransfer() (gas: 512732)
+```
+The subscriber was removed from `PositionManager` but `notifyTransfer` was never invoked.
+
+## Impact
+Subscribers expecting ownership updates will maintain stale state. They are only informed of unsubscription, not of the new owner, breaking any reward or voting logic that should follow the token.
+
+## Recommendations
+Implement a transfer hook. Override `_afterTokenTransfer` (or `transferFrom`) to call `notifyTransfer` with a gas-capped `try/catch`, similar to other notifications, and keep the subscriber mapping intact if continued subscription is desired.

--- a/test/mocks/MockTransferSubscriber.sol
+++ b/test/mocks/MockTransferSubscriber.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ISubscriber} from "../../src/interfaces/ISubscriber.sol";
+import {IPositionManager} from "../../src/interfaces/IPositionManager.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {PositionInfo} from "../../src/libraries/PositionInfoLibrary.sol";
+
+/// @notice Subscriber mock that tracks notifyTransfer calls
+contract MockTransferSubscriber is ISubscriber {
+    IPositionManager public posm;
+
+    uint256 public notifySubscribeCount;
+    uint256 public notifyUnsubscribeCount;
+    uint256 public notifyModifyLiquidityCount;
+    uint256 public notifyBurnCount;
+    uint256 public notifyTransferCount;
+
+    address public oldOwner;
+    address public newOwner;
+
+    int256 public liquidityChange;
+    BalanceDelta public feesAccrued;
+
+    bytes public subscribeData;
+
+    error NotAuthorizedNotifier(address sender);
+
+    constructor(IPositionManager _posm) {
+        posm = _posm;
+    }
+
+    modifier onlyByPosm() {
+        if (msg.sender != address(posm)) revert NotAuthorizedNotifier(msg.sender);
+        _;
+    }
+
+    function notifySubscribe(uint256, bytes memory data) external onlyByPosm {
+        notifySubscribeCount++;
+        subscribeData = data;
+    }
+
+    function notifyUnsubscribe(uint256) external onlyByPosm {
+        notifyUnsubscribeCount++;
+    }
+
+    function notifyModifyLiquidity(uint256, int256 _liquidityChange, BalanceDelta _feesAccrued) external onlyByPosm {
+        notifyModifyLiquidityCount++;
+        liquidityChange = _liquidityChange;
+        feesAccrued = _feesAccrued;
+    }
+
+    function notifyBurn(uint256, address, PositionInfo, uint256, BalanceDelta) external onlyByPosm {
+        notifyBurnCount++;
+    }
+
+    function notifyTransfer(uint256, address _oldOwner, address _newOwner) external onlyByPosm {
+        notifyTransferCount++;
+        oldOwner = _oldOwner;
+        newOwner = _newOwner;
+    }
+}

--- a/test/position-managers/PositionManager.notifyTransfer.t.sol
+++ b/test/position-managers/PositionManager.notifyTransfer.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {IERC721} from "forge-std/interfaces/IERC721.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+
+import {PosmTestSetup} from "../shared/PosmTestSetup.sol";
+import {PositionConfig} from "../shared/PositionConfig.sol";
+import {MockTransferSubscriber} from "../mocks/MockTransferSubscriber.sol";
+import {IPositionManager} from "../../src/interfaces/IPositionManager.sol";
+
+contract NotifyTransferTest is Test, PosmTestSetup {
+    MockTransferSubscriber sub;
+    PositionConfig config;
+
+    address alice = makeAddr("ALICE");
+    address bob = makeAddr("BOB");
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+
+        (key,) = initPool(currency0, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1);
+
+        deployAndApprovePosm(manager);
+
+        sub = new MockTransferSubscriber(lpm);
+
+        config = PositionConfig({poolKey: key, tickLower: -300, tickUpper: 300});
+    }
+
+    function test_safeTransfer_doesNotNotifyTransfer() public {
+        uint256 tokenId = lpm.nextTokenId();
+        mint(config, 100e18, alice, ZERO_BYTES);
+
+        vm.startPrank(alice);
+        IERC721(address(lpm)).approve(address(this), tokenId);
+        vm.stopPrank();
+
+        lpm.subscribe(tokenId, address(sub), ZERO_BYTES);
+
+        IERC721(address(lpm)).safeTransferFrom(alice, bob, tokenId);
+
+        assertEq(sub.notifyTransferCount(), 0);
+        assertEq(address(lpm.subscriber(tokenId)), address(0));
+    }
+
+    function test_transferFrom_doesNotNotifyTransfer() public {
+        uint256 tokenId = lpm.nextTokenId();
+        mint(config, 100e18, alice, ZERO_BYTES);
+
+        vm.startPrank(alice);
+        IERC721(address(lpm)).approve(address(this), tokenId);
+        vm.stopPrank();
+
+        lpm.subscribe(tokenId, address(sub), ZERO_BYTES);
+
+        IERC721(address(lpm)).transferFrom(alice, bob, tokenId);
+
+        assertEq(sub.notifyTransferCount(), 0);
+        assertEq(address(lpm.subscriber(tokenId)), address(0));
+    }
+}


### PR DESCRIPTION
## Summary
- add a `MockTransferSubscriber` that records `notifyTransfer`
- assert that `PositionManager` never calls `notifyTransfer` on transfers
- document findings in a new report

## Testing
- `forge test --match-path test/position-managers/PositionManager.notifyTransfer.t.sol -vvv`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685b3068c430832da577d6ebf5a7be45