### PR TITLE
Add tests for NativeWrapper wrap/unwrap helpers

### DIFF
--- a/reports/report-native-wrapper-wrap-unwrap-20250625.md
+++ b/reports/report-native-wrapper-wrap-unwrap-20250625.md
@@ -1,0 +1,18 @@
+# NativeWrapper Wrap/Unwrap Tests
+
+## Summary
+Added tests for `NativeWrapper` ensuring the helper functions `_wrap` and `_unwrap` correctly convert ETH to WETH and vice versa. Both paths were previously untested.
+
+## Methodology
+- Identified that `NativeWrapper.t.sol` only checked the `receive` function. 
+- Added two tests calling the harness `wrap` and `unwrap` functions directly and verifying token and ETH balances change as expected.
+
+## Test Steps
+- `test_wrap_deposits_weth` sends 1 ETH to the wrapper and checks the wrapper's WETH balance increases by 1 ETH after wrapping.
+- `test_unwrap_withdraws_weth` deposits 2 ETH then unwraps 1 ETH, verifying the wrapper's WETH balance decreases and ETH balance increases.
+
+## Findings
+- Both new tests pass showing the contract handles direct wrapping and unwrapping correctly. No issues were observed.
+
+## Conclusion
+The additional tests cover previously untouched code in `NativeWrapper`, increasing assurance that wrapping and unwrapping behave as intended.

--- a/test/NativeWrapper.t.sol
+++ b/test/NativeWrapper.t.sol
@@ -57,4 +57,21 @@ contract NativeWrapperTest is Test {
         vm.deal(address(manager), 1 ether);
         manager.sendEther{value: 1 ether}(payable(address(wrapper)));
     }
+
+    function test_wrap_deposits_weth() public {
+        vm.deal(address(this), 1 ether);
+        uint256 beforeWeth = weth.balanceOf(address(wrapper));
+        wrapper.wrap{value: 1 ether}(1 ether);
+        assertEq(weth.balanceOf(address(wrapper)) - beforeWeth, 1 ether);
+    }
+
+    function test_unwrap_withdraws_weth() public {
+        vm.deal(address(this), 2 ether);
+        wrapper.wrap{value: 2 ether}(2 ether);
+        uint256 beforeWeth = weth.balanceOf(address(wrapper));
+        uint256 beforeEth = address(wrapper).balance;
+        wrapper.unwrap(1 ether);
+        assertEq(beforeWeth - weth.balanceOf(address(wrapper)), 1 ether);
+        assertEq(address(wrapper).balance - beforeEth, 1 ether);
+    }
 }


### PR DESCRIPTION
## Summary
- run the test suite
- add coverage for `NativeWrapper` wrapping helpers
- document the new tests

## Testing
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685b4a3a45a4832d8430c8df487c25b5