### PR TITLE
Add Base64 decode revert test

### DIFF
--- a/reports/report-base64-invalid-length-20250625.md
+++ b/reports/report-base64-invalid-length-20250625.md
@@ -1,0 +1,15 @@
+# Base64 Decode Edge Case Test
+
+## Summary
+Added a new test covering the Base64 decode helper to ensure it reverts for inputs with invalid length. This increases coverage of utility libraries.
+
+## Methodology
+- Identified that `Base64.decode` had no negative tests.
+- Created `DecodeCaller` contract to call the library in a new test `Base64Test`.
+- The test passes a malformed base64 string and expects the revert message.
+
+## Findings
+- The library correctly reverts with `invalid base64 decoder input` when the length is not divisible by four.
+
+## Conclusion
+All tests including the new one pass, confirming correct error handling in the Base64 library.

--- a/test/Base64.t.sol
+++ b/test/Base64.t.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {Base64} from "./base64.sol";
+import {DecodeCaller} from "./DecodeCaller.sol";
+
+contract Base64Test is Test {
+    function test_decode_invalidLength_reverts() public {
+        DecodeCaller caller = new DecodeCaller();
+        string memory bad = "abcd="; // length 5 not divisible by 4
+        vm.expectRevert(bytes("invalid base64 decoder input"));
+        caller.callDecode(bad);
+    }
+}

--- a/test/DecodeCaller.sol
+++ b/test/DecodeCaller.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+import {Base64} from "./base64.sol";
+contract DecodeCaller {
+    function callDecode(string memory s) external pure returns (bytes memory) {
+        return Base64.decode(s);
+    }
+}


### PR DESCRIPTION
## Summary
- add DecodeCaller helper and Base64 test for invalid input
- document the new test in a report

## Testing
- `forge test --match-contract Base64Test -vv`
- `time forge test`

------
https://chatgpt.com/codex/tasks/task_e_685b53f7cc18832db038fce124cf09c7