### PR TITLE
Add tests for wrapper hook orientation

### DIFF
--- a/reports/report-WrapOrientation-20250625.md
+++ b/reports/report-WrapOrientation-20250625.md
@@ -1,0 +1,21 @@
+# Wrap Orientation and Rate Calculations
+
+This report documents additional tests for token wrapper hooks in Uniswap V4. The goal was to verify the orientation flag and rate helpers exposed by `BaseTokenWrapperHook` implementations.
+
+## Test Methodology
+- Created a harness `WstETHHookHarness` exposing internal view functions.
+- Added `WETHHookInternalTest` and `WstETHHookInternalTest` to check:
+  - `wrapZeroForOne` is computed based on token ordering.
+  - Rate helper functions `_getWrapInputRequired` and `_getUnwrapInputRequired` match expectations for the wstETH exchange rate.
+
+## Test Steps
+- Deploy hooks at deterministic addresses with proper permissions using `deployCodeTo`.
+- Call public harness functions and assert returned values.
+
+## Findings
+- Both hooks report `wrapZeroForOne` as `true` when the underlying token address is less than the wrapper token address.
+- Required amounts from the rate helper functions matched the mocked exchange rate, including rounding behavior.
+- No defects were discovered; tests passed as expected.
+
+## Conclusion
+The new tests cover internal logic previously untested around orientation and rate calculations for wrapper hooks. All checks succeeded.

--- a/test/harness/WstETHHookHarness.sol
+++ b/test/harness/WstETHHookHarness.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.24;
+
+import {WstETHHook} from "../../src/hooks/WstETHHook.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {IWstETH} from "../../src/interfaces/external/IWstETH.sol";
+
+/// @dev Harness exposing internal view functions for testing
+contract WstETHHookHarness is WstETHHook {
+    constructor(IPoolManager _manager, IWstETH _wsteth) WstETHHook(_manager, _wsteth) {}
+
+    function getWrapInputRequired(uint256 amount) external view returns (uint256) {
+        return _getWrapInputRequired(amount);
+    }
+
+    function getUnwrapInputRequired(uint256 amount) external view returns (uint256) {
+        return _getUnwrapInputRequired(amount);
+    }
+}

--- a/test/hooks/WETHHookInternal.t.sol
+++ b/test/hooks/WETHHookInternal.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {WETHHook} from "../../src/hooks/WETHHook.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+
+contract WETHHookInternalTest is Test, Deployers {
+    WETHHook public hook;
+    WETH public weth;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        weth = new WETH();
+        hook = WETHHook(
+            payable(
+                address(
+                    uint160(
+                        type(uint160).max & clearAllHookPermissionsMask |
+                            Hooks.BEFORE_SWAP_FLAG |
+                            Hooks.BEFORE_ADD_LIQUIDITY_FLAG |
+                            Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG |
+                            Hooks.BEFORE_INITIALIZE_FLAG
+                    )
+                )
+            )
+        );
+        deployCodeTo("WETHHook", abi.encode(manager, weth), address(hook));
+    }
+
+    function test_wrapZeroForOne_orientation() public {
+        bool expected = address(0) < address(weth);
+        assertEq(hook.wrapZeroForOne(), expected);
+    }
+}

--- a/test/hooks/WstETHHookInternal.t.sol
+++ b/test/hooks/WstETHHookInternal.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {WstETHHookHarness} from "../harness/WstETHHookHarness.sol";
+import {MockWstETH} from "../mocks/MockWstETH.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+
+contract WstETHHookInternalTest is Test, Deployers {
+    WstETHHookHarness public hook;
+    MockWstETH public wstETH;
+    MockERC20 public stETH;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        stETH = new MockERC20("stETH", "STETH", 18);
+        wstETH = new MockWstETH(address(stETH));
+        hook = WstETHHookHarness(
+            payable(
+                address(
+                    uint160(
+                        type(uint160).max & clearAllHookPermissionsMask |
+                            Hooks.BEFORE_SWAP_FLAG |
+                            Hooks.BEFORE_ADD_LIQUIDITY_FLAG |
+                            Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG |
+                            Hooks.BEFORE_INITIALIZE_FLAG
+                    )
+                )
+            )
+        );
+        deployCodeTo(
+            "WstETHHookHarness",
+            abi.encode(manager, wstETH),
+            address(hook)
+        );
+    }
+
+    function test_wrapZeroForOne_orientation() public {
+        bool expected = address(stETH) < address(wstETH);
+        assertEq(hook.wrapZeroForOne(), expected);
+    }
+
+    function test_internal_rate_calculations() public {
+        uint256 unwrapTarget = 1 ether;
+        uint256 requiredWst = hook.getUnwrapInputRequired(unwrapTarget);
+        assertEq(requiredWst, wstETH.getWstETHByStETH(unwrapTarget));
+
+        uint256 wrapTarget = 2 ether;
+        uint256 tokensPerStEth = wstETH.tokensPerStEth();
+        uint256 expectedSt = (wrapTarget * 1e18 + tokensPerStEth - 1) / tokensPerStEth;
+        uint256 requiredSt = hook.getWrapInputRequired(wrapTarget);
+        assertEq(requiredSt, expectedSt);
+    }
+}


### PR DESCRIPTION
## Summary
- add harness exposing internal helpers in `WstETHHook`
- test `wrapZeroForOne` orientation for WETHHook and WstETHHook
- verify `_getWrapInputRequired` and `_getUnwrapInputRequired` calculations
- document the new tests in `reports/report-WrapOrientation-20250625.md`

## Testing
- `forge test --match-path 'test/hooks/*Internal.t.sol' -vv`
- `forge test -vv`

------
https://chatgpt.com/codex/tasks/task_e_685b6262a58c832d8347cc0bb86f5d61