### PR TITLE
Add hex string truncation test

### DIFF
--- a/reports/report-HexStringsTruncation-20250625-0343.md
+++ b/reports/report-HexStringsTruncation-20250625-0343.md
@@ -1,0 +1,21 @@
+# HexStrings truncation behaviour
+
+## Summary
+This report adds a unit test to document how `HexStrings.toHexStringNoPrefix` handles numbers that require
+more digits than the provided length. The function simply truncates the higher-order digits.
+
+## Test Methodology
+A new test `test_toHexStringNoPrefix_truncates_excess` was added. It calls the library with a value larger than
+fits in the requested length and asserts that only the least significant digits are returned.
+
+## Test Steps
+- Invoke `HexStrings.toHexStringNoPrefix(0x123456, 2)`.
+- Expect the resulting string to equal `"3456"`.
+
+## Findings
+- The test passed, confirming the library truncates without reverting.
+- No issues were identified; the behaviour is consistent with existing assumptions.
+
+## Conclusion
+The additional test improves documentation of edge cases around hexadecimal string formatting.
+No functional bugs were found.

--- a/test/libraries/HexStrings.t.sol
+++ b/test/libraries/HexStrings.t.sol
@@ -14,4 +14,9 @@ contract HexStringsTest is Test {
         string memory hexStr = HexStrings.toHexStringNoPrefix(0x1, 2);
         assertEq(hexStr, "0001");
     }
+
+    function test_toHexStringNoPrefix_truncates_excess() public pure {
+        string memory hexStr = HexStrings.toHexStringNoPrefix(0x123456, 2);
+        assertEq(hexStr, "3456");
+    }
 }


### PR DESCRIPTION
## Summary
- run full `forge test`
- add edge test for `HexStrings.toHexStringNoPrefix` when value exceeds length
- document behaviour in a new report

## Testing
- `forge test`


------
https://chatgpt.com/codex/tasks/task_e_685b6d6f7b2c832d932693d96366078f