### PR TITLE
Add Locker default state test

### DIFF
--- a/reports/report-locker-default-20250625-01.md
+++ b/reports/report-locker-default-20250625-01.md
@@ -1,0 +1,18 @@
+# Locker Default State Test
+
+## Summary
+Added a small test confirming that `Locker.get()` returns the zero address when no locker has been set.
+
+## Methodology
+The new unit test instantiates a `LockerHarness` and immediately calls `getLocker()` without calling `setLocker` first.
+
+## Test Steps
+- Deploy `LockerHarness`.
+- Invoke `getLocker()` before any call to `setLocker`.
+- Assert the returned address is `address(0)`.
+
+## Findings
+The test passed, verifying that the library's transient storage slot is empty by default.
+
+## Conclusion
+`Locker.get()` correctly returns the zero address prior to initialization. This guards against unexpected non-zero values when using the library for the first time.

--- a/test/libraries/Locker.t.sol
+++ b/test/libraries/Locker.t.sol
@@ -37,4 +37,8 @@ contract LockerTest is Test {
         address result = harness.setAndReturn(address(0xCAFE));
         assertEq(result, address(0xCAFE));
     }
+
+    function test_get_without_set_returns_zero() public {
+        assertEq(harness.getLocker(), address(0));
+    }
 }


### PR DESCRIPTION
## Summary
- add test for Locker library to ensure get() returns zero before set
- document the behavior in a short report

## Testing
- `forge test -vvv`


------
https://chatgpt.com/codex/tasks/task_e_685b6d6f7b2c832d932693d96366078f