### PR TITLE
Add BaseHook address validation test

### DIFF
--- a/reports/report-BaseHookValidateAddress-20250625-01.md
+++ b/reports/report-BaseHookValidateAddress-20250625-01.md
@@ -1,0 +1,19 @@
+# BaseHook Address Validation
+
+This report documents a new test ensuring that `BaseHook` reverts during construction when the deployed address does not match the expected permission flags.
+
+## Test Methodology
+- A `BadHook` contract extending `BaseHook` returns permissions that set the `BEFORE_INITIALIZE` flag.
+- Using `HookMiner.computeAddress`, the test calculates a CREATE2 address which does **not** match these flags.
+- Deploying `BadHook` at this address must revert with `Hooks.HookAddressNotValid`.
+
+## Test Steps
+- Predict address for the chosen salt.
+- Ensure its lower 14 bits differ from the desired flag.
+- Expect revert and attempt deployment with the same salt.
+
+## Findings
+- Deployment fails as expected, confirming the validation logic rejects mismatched addresses.
+
+## Conclusion
+The added test covers a revert path previously untested in `BaseHook`, improving confidence in hook deployment safety.

--- a/test/BaseHookValidateAddress.t.sol
+++ b/test/BaseHookValidateAddress.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {BaseHook} from "../src/utils/BaseHook.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {HookMiner} from "../src/utils/HookMiner.sol";
+
+contract DummyPoolManager2 {}
+
+contract BadHook is BaseHook {
+    constructor(IPoolManager manager) BaseHook(manager) {}
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory perm) {
+        perm = Hooks.Permissions({
+            beforeInitialize: true,
+            afterInitialize: false,
+            beforeAddLiquidity: false,
+            afterAddLiquidity: false,
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeSwap: false,
+            afterSwap: false,
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: false,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+}
+
+contract BaseHookValidateAddressTest is Test {
+    function test_constructor_reverts_when_address_mismatch() public {
+        DummyPoolManager2 pm = new DummyPoolManager2();
+        bytes memory bytecode = abi.encodePacked(type(BadHook).creationCode, abi.encode(IPoolManager(address(pm))));
+        uint160 flags = uint160(Hooks.BEFORE_INITIALIZE_FLAG);
+        bytes32 salt = bytes32(uint256(1));
+        address predicted = HookMiner.computeAddress(address(this), uint256(salt), bytecode);
+        if ((uint160(predicted) & Hooks.ALL_HOOK_MASK) == flags) {
+            salt = bytes32(uint256(2));
+            predicted = HookMiner.computeAddress(address(this), uint256(salt), bytecode);
+        }
+        vm.expectRevert(abi.encodeWithSelector(Hooks.HookAddressNotValid.selector, predicted));
+        new BadHook{salt: salt}(IPoolManager(address(pm)));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add test ensuring BaseHook constructor reverts when deployed at an address with mismatched permission flags
- document the new coverage in a report

## Testing
- `forge test --match-test constructor_reverts_when_address_mismatch -vvv`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685b6d6f7b2c832d932693d96366078f