### PR TITLE
Add Notifier success path tests

### DIFF
--- a/reports/report-notifier-success-paths-20250625.md
+++ b/reports/report-notifier-success-paths-20250625.md
@@ -1,0 +1,18 @@
+# Notifier Success Path Coverage
+
+This report documents adding tests for previously uncovered success paths in the `Notifier` contract.
+
+## Test Methodology
+- Reviewed current coverage reports and observed that `Notifier` tests only covered revert scenarios.
+- Added focused tests for `_call` and `_notifyModifyLiquidity` to validate expected behavior when calls succeed.
+
+## Test Steps
+- `test_callWrap_success` verifies `_call` returns `true` and increments a `subscribeCount` when invoking a compliant subscriber contract.
+- `test_notifyModifyLiquidity_success` checks that a subscribed address receives a modify notification without reverting.
+
+## Findings
+- Both new tests passed, confirming correct handling of successful paths.
+- No unexpected behavior was detected.
+
+## Conclusion
+The added tests improve coverage for `Notifier`'s success paths and complement existing revert case tests. No functional issues were found.

--- a/test/NotifierHarness.t.sol
+++ b/test/NotifierHarness.t.sol
@@ -6,6 +6,7 @@ import {NotifierHarness} from "./mocks/NotifierHarness.sol";
 import {SimpleSubscriber} from "./mocks/SimpleSubscriber.sol";
 import {SimpleRevertSubscriber} from "./mocks/SimpleRevertSubscriber.sol";
 import {INotifier} from "../src/interfaces/INotifier.sol";
+import {ISubscriber} from "../src/interfaces/ISubscriber.sol";
 import {PositionInfo} from "../src/libraries/PositionInfoLibrary.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 
@@ -33,6 +34,14 @@ contract NotifierHarnessTest is Test {
         assertEq(sub.unsubscribeCount(), 1);
     }
 
+    function test_callWrap_success() public {
+        SimpleSubscriber sub = new SimpleSubscriber();
+        bytes memory data = abi.encodeCall(ISubscriber.notifySubscribe, (1, ""));
+        bool success = harness.callWrap(address(sub), data);
+        assertTrue(success);
+        assertEq(sub.subscribeCount(), 1);
+    }
+
     function test_removeSubscriberAndNotifyBurn() public {
         SimpleSubscriber sub = new SimpleSubscriber();
         harness.subscribe(2, address(sub), "");
@@ -46,5 +55,12 @@ contract NotifierHarnessTest is Test {
         harness.subscribe(3, address(sub), "");
         vm.expectRevert();
         harness.notifyModifyLiquidityWrap(3, 1, BalanceDelta.wrap(0));
+    }
+
+    function test_notifyModifyLiquidity_success() public {
+        SimpleSubscriber sub = new SimpleSubscriber();
+        harness.subscribe(4, address(sub), "");
+        harness.notifyModifyLiquidityWrap(4, 1, BalanceDelta.wrap(0));
+        assertEq(sub.modifyCount(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- add tests for successful _call and _notifyModifyLiquidity
- document coverage update in new report

## Testing
- `forge test --match-contract NotifierHarnessTest -vv`
- `forge test --summary` (full suite)


------
https://chatgpt.com/codex/tasks/task_e_685b6d6f7b2c832d932693d96366078f