### PR TITLE
Add overflow regression test

### DIFF
--- a/reports/report-20250625-0413-tokenId-overflow.md
+++ b/reports/report-20250625-0413-tokenId-overflow.md
@@ -1,0 +1,19 @@
+# Token ID Overflow in PositionManager
+
+## Summary
+Using Forge's `stdstore` cheatcode we forced `nextTokenId` to `uint256.max` then minted twice. The first mint sets `nextTokenId` to `0` and the second mint reuses token ID `0`. This violates the reserved ID scheme and proves the unchecked increment can wrap.
+
+## Methodology
+1. Deployed a fresh PositionManager via `PosmTestSetup`.
+2. Overwrote `nextTokenId` storage with `type(uint256).max`.
+3. Minted two positions from an approved account.
+4. Asserted that `nextTokenId` reset to `1` and `ownerOf(0)` returned the minter.
+
+## Test Results
+```
+$ forge test -vvv --match-path test/TokenIdOverflow.t.sol
+[PASS] testOverflowNextTokenId() (gas: 679595)
+```
+
+## Recommendation
+Add a check before incrementing to revert if `nextTokenId` is `type(uint256).max`. This prevents wrap-around and preserves the skip-0 invariant.

--- a/test/TokenIdOverflow.t.sol
+++ b/test/TokenIdOverflow.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IERC721} from "forge-std/interfaces/IERC721.sol";
+import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
+import {PositionConfig} from "./shared/PositionConfig.sol";
+
+contract TokenIdOverflowTest is Test, PosmTestSetup {
+    using stdStorage for StdStorage;
+    StdStorage store;
+    PositionConfig config;
+    address alice = makeAddr("ALICE");
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+        (key,) = initPool(currency0, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1);
+        deployAndApprovePosm(manager);
+        seedBalance(alice);
+        approvePosmFor(alice);
+        config = PositionConfig({poolKey: key, tickLower: -300, tickUpper: 300});
+    }
+
+    function testOverflowNextTokenId() public {
+        // Force nextTokenId to max uint256
+        store.target(address(lpm)).sig("nextTokenId()").checked_write(type(uint256).max);
+
+        // First mint causes nextTokenId to wrap to zero
+        vm.startPrank(alice);
+        mint(config, 1e18, alice, "");
+        vm.stopPrank();
+
+        // Next mint should reuse tokenId 0 due to overflow
+        vm.startPrank(alice);
+        mint(config, 1e18, alice, "");
+        vm.stopPrank();
+
+        assertEq(lpm.nextTokenId(), 1);
+        assertEq(IERC721(address(lpm)).ownerOf(0), alice);
+    }
+}


### PR DESCRIPTION
## Summary
- test overflow of nextTokenId when it wraps
- document the bug and remediation idea

## Testing
- `forge test -vvv --match-path test/TokenIdOverflow.t.sol`

------
https://chatgpt.com/codex/tasks/task_e_685b74de5a88832dbe8a208b233420f5