### PR TITLE
Add Base64 roundtrip test

### DIFF
--- a/reports/report-base64-roundtrip-20250625-01.md
+++ b/reports/report-base64-roundtrip-20250625-01.md
@@ -1,0 +1,18 @@
+# Base64 Roundtrip Test Report
+
+This report documents the addition of a regression test verifying that the custom `Base64.decode` helper correctly decodes a well formed Base64 string.
+
+## Methodology
+- Executed the full `forge test` suite for the periphery repository and the core submodule.
+- Observed that `Base64` decoding had only negative coverage. Added a minimal positive test using the existing `DecodeCaller` harness.
+
+## Test Steps
+- Created `Base64RoundtripTest` which calls `DecodeCaller.callDecode` with the Base64 string `"dGVzdA=="` ("test" in Base64).
+- Asserted that the returned bytes match `"test"`.
+
+## Findings
+- The new test passes, confirming correct behaviour for valid input.
+- No code issues were uncovered during execution.
+
+## Conclusion
+All tests, including the new roundtrip test, pass successfully. This improves coverage of the Base64 utility and ensures future changes do not break valid decoding.

--- a/test/Base64Roundtrip.t.sol
+++ b/test/Base64Roundtrip.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {DecodeCaller} from "./DecodeCaller.sol";
+
+contract Base64RoundtripTest is Test {
+    function test_decode_roundtrip() public {
+        DecodeCaller caller = new DecodeCaller();
+        bytes memory out = caller.callDecode("dGVzdA==");
+        assertEq(out, bytes("test"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Base64Roundtrip test for decode helper
- document results in report-base64-roundtrip-20250625-01

## Testing
- `forge test --match-path test/Base64Roundtrip.t.sol -vv`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685b74f71160832d9fb994c42efb77c6