### PR TITLE
Add ReentrancyLock tests

### DIFF
--- a/reports/report-ReentrancyLock-20250625-0400.md
+++ b/reports/report-ReentrancyLock-20250625-0400.md
@@ -1,0 +1,21 @@
+# ReentrancyLock Edge Cases - 20250625
+
+## Summary
+This report documents additional tests around the `ReentrancyLock` contract. The goal was to verify the modifier correctly records the caller address during execution and prevents reentrant calls.
+
+## Test Methodology
+`ReentrancyLock` was identified as lightly tested because no dedicated test covered `_getLocker()` or the transient storage lock. A new harness contract exposes methods to inspect the locker state and attempt reentrancy. Two focused tests were written:
+- **test_lock_and_unlock** checks that the lock stores `msg.sender` during the call and clears afterwards.
+- **test_reentrant_call_reverts** triggers a nested call while locked expecting failure and ensuring the lock is cleared.
+
+## Test Steps
+1. Deploy `ReentrancyLockHarness` implementing `lockedCaller`, `reentrantAttempt`, and `currentLocker`.
+2. Call `lockedCaller` and assert it returns the caller and that `currentLocker` is zero after.
+3. Call `reentrantAttempt` which internally calls `lockedCaller` again. Assert the nested call fails and the lock resets to zero.
+
+## Findings
+- Both tests pass indicating `isNotLocked` correctly sets and clears the locker and reverts on reentrant calls.
+- No functional issues were revealed. The tests increase coverage for the lock mechanism.
+
+## Conclusion
+`ReentrancyLock` now has direct tests validating its behavior. Future work could integrate similar checks in other contracts relying on the lock for improved assurance.

--- a/test/ReentrancyLock.t.sol
+++ b/test/ReentrancyLock.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {ReentrancyLock} from "../src/base/ReentrancyLock.sol";
+
+contract ReentrancyLockHarness is ReentrancyLock {
+    function lockedCaller() external isNotLocked returns (address) {
+        return _getLocker();
+    }
+
+    function reentrantAttempt() external isNotLocked returns (bool) {
+        (bool success,) = address(this).call(abi.encodeWithSelector(this.lockedCaller.selector));
+        return success;
+    }
+
+    function currentLocker() external view returns (address) {
+        return _getLocker();
+    }
+}
+
+contract ReentrancyLockTest is Test {
+    ReentrancyLockHarness harness;
+
+    function setUp() public {
+        harness = new ReentrancyLockHarness();
+    }
+
+    function test_lock_and_unlock() public {
+        address locker = harness.lockedCaller();
+        assertEq(locker, address(this));
+        assertEq(harness.currentLocker(), address(0));
+    }
+
+    function test_reentrant_call_reverts() public {
+        bool success = harness.reentrantAttempt();
+        assertTrue(!success);
+        assertEq(harness.currentLocker(), address(0));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for ReentrancyLock
- document findings in new report

## Testing
- `forge test -vvv --match-contract ReentrancyLockTest`
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685b74f71160832d9fb994c42efb77c6