### PR TITLE
Add slippage check tests

### DIFF
--- a/reports/report-slippage-tests-20250625-01.md
+++ b/reports/report-slippage-tests-20250625-01.md
@@ -1,0 +1,18 @@
+# SlippageCheck Additional Tests
+
+This report adds targeted unit tests for the `SlippageCheck` library.
+
+## Test Methodology
+- Baseline coverage indicated modest coverage for `SlippageCheck` functions.
+- Added tests exercise success paths of `validateMaxIn` and `validateMinOut` that were previously untested.
+
+## Test Steps
+- `test_validateMaxIn_withinLimits` verifies that negative deltas within provided maximums do not revert.
+- `test_validateMinOut_succeeds` ensures positive deltas meeting minimum outputs pass validation.
+
+## Findings
+- All new tests pass and no new issues were found.
+- Coverage numbers are largely unchanged (~78% line coverage).
+
+## Conclusion
+The new tests strengthen assurance around edge cases of the slippage library without exposing flaws.

--- a/test/libraries/SlippageCheck.t.sol
+++ b/test/libraries/SlippageCheck.t.sol
@@ -38,5 +38,15 @@ contract SlippageCheckTest is Test {
         vm.expectRevert();
         harness.callValidateMinOut(delta, 1, 0);
     }
+
+    function test_validateMaxIn_withinLimits() public {
+        BalanceDelta delta = toBalanceDelta(-5, -3);
+        harness.callValidateMaxIn(delta, 5, 3);
+    }
+
+    function test_validateMinOut_succeeds() public {
+        BalanceDelta delta = toBalanceDelta(5, 6);
+        harness.callValidateMinOut(delta, 5, 6);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add additional tests for `SlippageCheck`
- document the new tests in a report

## Testing
- `forge test`
- `forge coverage`

------
https://chatgpt.com/codex/tasks/task_e_685b74f71160832d9fb994c42efb77c6