### PR TITLE
Add stale subscriber transfer test and report

### DIFF
--- a/reports/report-20250625-0449-stale-subscriber.md
+++ b/reports/report-20250625-0449-stale-subscriber.md
@@ -1,0 +1,35 @@
+# Stale Subscriber After Transfer
+
+## Summary
+This test attempted to verify that transferring a position via `transferFrom` or `safeTransferFrom` leaves the original subscriber mapped to the token. The expectation was that the subscriber mapping would persist and no `notifyTransfer` call would occur.
+
+## Methodology
+- Reviewed `src/base/Notifier.sol` which stores subscribers in `mapping(uint256 => ISubscriber)` without an automatic transfer hook.
+- Examined `src/PositionManager.sol` where `transferFrom` overrides Solmate's implementation. It unsubscribes the position if a subscriber exists:
+  ```solidity
+  function transferFrom(address from, address to, uint256 id) public override onlyIfPoolManagerLocked {
+      super.transferFrom(from, to, id);
+      if (positionInfo[id].hasSubscriber()) _unsubscribe(id);
+  }
+  ```
+- Wrote `test/StaleSubscriberOnTransfer.t.sol` to transfer an NFT after subscribing and check that the subscriber remains attached.
+
+## Test Steps
+1. Minted a position and subscribed a mock subscriber.
+2. Called `safeTransferFrom` and `transferFrom` from the owner to another account.
+3. Checked `sub.notifyTransferCount()` and `pos.subscriber(tid)` after each transfer.
+
+## Findings
+The test failed: after each transfer, `subscriber(tokenId)` returned `address(0)`, showing that the position manager automatically unsubscribes during `transferFrom`. No `notifyTransfer` callback was observed.
+
+Forge output:
+```
+[FAIL] test_safeTransfer_keepsSubscriber() assertion failed
+[FAIL] test_transferFrom_keepsSubscriber() assertion failed
+```
+
+## Conclusion & Recommendation
+In the current repository state, transferring a position clears the subscriber mapping and does not trigger a `notifyTransfer` callback. The stale subscriber scenario described in the objective was not reproducible. If subscriber persistence is desired, remove the `_unsubscribe(id)` call in `transferFrom` and implement `notifyTransfer` logic instead.
+
+## References
+- [`src/PositionManager.sol`](../../src/PositionManager.sol) lines 536-539 show the unsubscribe logic.

--- a/test/StaleSubscriberOnTransfer.t.sol
+++ b/test/StaleSubscriberOnTransfer.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {IERC721} from "forge-std/interfaces/IERC721.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+
+import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
+import {PositionConfig} from "./shared/PositionConfig.sol";
+import {MockTransferSubscriber} from "./mocks/MockTransferSubscriber.sol";
+import {IPositionManager} from "../../src/interfaces/IPositionManager.sol";
+
+contract StaleSubscriberTest is Test, PosmTestSetup {
+    MockTransferSubscriber sub;
+    PositionConfig config;
+
+    address alice = makeAddr("ALICE");
+    address bob = makeAddr("BOB");
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+
+        (key,) = initPool(currency0, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1);
+
+        deployAndApprovePosm(manager);
+
+        sub = new MockTransferSubscriber(lpm);
+
+        config = PositionConfig({poolKey: key, tickLower: -300, tickUpper: 300});
+    }
+
+    function test_safeTransfer_keepsSubscriber() public {
+        uint256 tokenId = lpm.nextTokenId();
+        mint(config, 100e18, alice, ZERO_BYTES);
+
+        vm.startPrank(alice);
+        IERC721(address(lpm)).approve(address(this), tokenId);
+        vm.stopPrank();
+
+        lpm.subscribe(tokenId, address(sub), ZERO_BYTES);
+
+        IERC721(address(lpm)).safeTransferFrom(alice, bob, tokenId);
+
+        assertEq(sub.notifyTransferCount(), 0);
+        assertEq(address(lpm.subscriber(tokenId)), address(sub));
+    }
+
+    function test_transferFrom_keepsSubscriber() public {
+        uint256 tokenId = lpm.nextTokenId();
+        mint(config, 100e18, alice, ZERO_BYTES);
+
+        vm.startPrank(alice);
+        IERC721(address(lpm)).approve(address(this), tokenId);
+        vm.stopPrank();
+
+        lpm.subscribe(tokenId, address(sub), ZERO_BYTES);
+
+        IERC721(address(lpm)).transferFrom(alice, bob, tokenId);
+
+        assertEq(sub.notifyTransferCount(), 0);
+        assertEq(address(lpm.subscriber(tokenId)), address(sub));
+    }
+}


### PR DESCRIPTION
## Summary
- add StaleSubscriberOnTransfer.t.sol test checking subscriber after NFT transfer
- document results in report-20250625-0449-stale-subscriber.md

## Testing
- `forge test -vvv --match-path test/StaleSubscriberOnTransfer.t.sol` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_685b7dd274f4832d806ad33f0112ed2d