### PR TITLE
Add OPEN_DELTA balance revert test

### DIFF
--- a/reports/report-DeltaResolverOpenDeltaInsufficientBalance-20250625.md
+++ b/reports/report-DeltaResolverOpenDeltaInsufficientBalance-20250625.md
@@ -1,0 +1,20 @@
+# DeltaResolver OPEN_DELTA Insufficient Balance Test
+
+## Summary
+Added a new test covering `_mapWrapUnwrapAmount` when `OPEN_DELTA` exceeds the contract balance. The function should revert with `InsufficientBalance`.
+
+## Test Methodology
+- Initialized a harness contract and set a negative delta (`-10`) on the mock pool manager.
+- Minted only `5` tokens to the harness so its balance was less than the debt.
+- Called `expose_mapWrapUnwrapAmount` with `OPEN_DELTA` and expected a revert.
+
+## Test Steps
+1. Set the pool manager's delta for the harness to `-10` tokens.
+2. Mint `5` tokens to the harness.
+3. Expect `DeltaResolver.InsufficientBalance` revert when calling `_mapWrapUnwrapAmount` with `OPEN_DELTA`.
+
+## Findings
+- The test passed, confirming the revert path works when debt exceeds balance.
+
+## Conclusion
+This test increases coverage of `DeltaResolver` by asserting behavior for `OPEN_DELTA` with insufficient balance, which was previously untested.

--- a/test/DeltaResolverMapWrapUnwrap.t.sol
+++ b/test/DeltaResolverMapWrapUnwrap.t.sol
@@ -69,6 +69,13 @@ contract DeltaResolverMapWrapUnwrapTest is Test {
         assertEq(amount, 7);
     }
 
+    function test_openDelta_revertsInsufficientBalance() public {
+        manager.setDelta(address(harness), tokenCurrency, -10);
+        token.mint(address(harness), 5);
+        vm.expectRevert(DeltaResolver.InsufficientBalance.selector);
+        harness.expose_mapWrapUnwrapAmount(tokenCurrency, ActionConstants.OPEN_DELTA, tokenCurrency);
+    }
+
     function test_revertInsufficientBalance() public {
         token.mint(address(harness), 5);
         vm.expectRevert(DeltaResolver.InsufficientBalance.selector);


### PR DESCRIPTION
## Summary
- add missing test for `_mapWrapUnwrapAmount` when OPEN_DELTA is greater than available balance
- document the new test in reports

## Testing
- `forge test --match-test test_openDelta_revertsInsufficientBalance -vvv`
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685b7f445150832dac1f936ae0d23c94