### PR TITLE
Add V4Quoter unexpected success test

### DIFF
--- a/reports/report-v4quoter-unexpected-success-20250625.md
+++ b/reports/report-v4quoter-unexpected-success-20250625.md
@@ -1,0 +1,20 @@
+# V4Quoter unexpected success path coverage
+
+## Summary
+This report documents the addition of a test covering `BaseV4Quoter`'s `UnexpectedCallSuccess` revert. The goal was to verify that `unlockCallback` reverts when the delegated call does not revert as expected.
+
+## Methodology
+After reviewing existing tests, no case exercised the `UnexpectedCallSuccess` error in `BaseV4Quoter`. A minimal harness was built using a dummy `PoolManager` contract able to call `unlockCallback` on the quoter. The test invokes `unlockCallback` with data that calls `msgSender()`, which returns normally and should trigger the revert.
+
+## Test Steps
+- Deploy a `DummyPoolManager`.
+- Deploy `V4Quoter` using this dummy as the pool manager.
+- Encode a call to `quoter.msgSender()` and call `unlockCallback` via the dummy.
+- Expect `BaseV4Quoter.UnexpectedCallSuccess` to be reverted.
+
+## Findings
+- The test succeeded, confirming the quoter reverts with `UnexpectedCallSuccess` when the delegated call does not revert.
+- No bugs were found; the behavior matches expectations.
+
+## Conclusion
+The additional test improves coverage around `BaseV4Quoter`'s defensive revert path. No issues were uncovered, but the test ensures this edge case will remain verified in future changes.

--- a/test/quoter/V4QuoterUnexpectedSuccess.t.sol
+++ b/test/quoter/V4QuoterUnexpectedSuccess.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {V4Quoter} from "../../src/lens/V4Quoter.sol";
+import {BaseV4Quoter} from "../../src/base/BaseV4Quoter.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+contract DummyPoolManager {
+    function callUnlock(address quoter, bytes calldata data) external returns (bytes memory) {
+        return V4Quoter(quoter).unlockCallback(data);
+    }
+}
+
+contract V4QuoterUnexpectedSuccessTest is Test {
+    V4Quoter quoter;
+    DummyPoolManager manager;
+
+    function setUp() public {
+        manager = new DummyPoolManager();
+        quoter = new V4Quoter(IPoolManager(address(manager)));
+    }
+
+    function test_unlockCallback_unexpectedSuccess() public {
+        bytes memory data = abi.encodeCall(quoter.msgSender, ());
+        vm.expectRevert(BaseV4Quoter.UnexpectedCallSuccess.selector);
+        manager.callUnlock(address(quoter), data);
+    }
+}


### PR DESCRIPTION
## Summary
- test `BaseV4Quoter`'s `UnexpectedCallSuccess` revert using a dummy pool manager
- document the new test in `reports/`

## Testing
- `forge test -vvv`


------
https://chatgpt.com/codex/tasks/task_e_685b7f445150832dac1f936ae0d23c94