### PR TITLE
Add ownership check tests

### DIFF
--- a/reports/report-20250625-0659-ownership-checks-missing.md
+++ b/reports/report-20250625-0659-ownership-checks-missing.md
@@ -1,0 +1,38 @@
+# Ownership Checks Missing Validation Report
+
+## Summary
+No missing ownership checks were found in `PositionManager.sol`. All internal functions that modify positions (`_increase`, `_decrease`, `_burn`, etc.) guard their execution with the `onlyIfApproved` modifier. External calls that modify liquidity funnel through these internal methods, so unauthorized callers cannot change another user's position.
+
+## Methodology
+- Reviewed public entry points in `src/PositionManager.sol`.
+- Created `OwnershipChecks.t.sol` to attempt unauthorized calls for increasing, decreasing, collecting fees, burning, and using `modifyLiquiditiesWithoutUnlock`.
+- Ran tests with `forge` to verify that an unapproved address triggers `IPositionManager.NotApproved`.
+- Attempted to run `slither` static analysis; tool failed due to build-info path issues.
+
+## Test Steps
+1. Deploy pool and position manager.
+2. Mint a position to `alice`.
+3. From `bob` (unapproved):
+   - Call `modifyLiquidities` with encoded `INCREASE_LIQUIDITY` action.
+   - Call `modifyLiquidities` with encoded `DECREASE_LIQUIDITY` action.
+   - Call `modifyLiquidities` with encoded `DECREASE_LIQUIDITY` (0) to collect fees.
+   - Call `modifyLiquidities` with encoded `BURN_POSITION` action.
+   - Call `modifyLiquiditiesWithoutUnlock` with an increase action.
+4. Expect `NotApproved` revert for each call.
+
+## Findings
+All five tests passed showing each unauthorized attempt reverted:
+```
+[PASS] test_burn_unapproved_reverts()
+[PASS] test_collectFees_unapproved_reverts()
+[PASS] test_decreaseLiquidity_unapproved_reverts()
+[PASS] test_increaseLiquidity_unapproved_reverts()
+[PASS] test_modifyLiquiditiesWithoutUnlock_unapproved_reverts()
+```
+
+## Recommendations
+- No changes required. The current code correctly enforces ownership checks on position modifying actions.
+- Ensure future public entry points continue to use `onlyIfApproved`.
+
+## Verdict
+✅ No missing ownership checks were found.

--- a/test/OwnershipChecks.t.sol
+++ b/test/OwnershipChecks.t.sol
@@ -1,0 +1,73 @@
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPositionManager} from "../src/interfaces/IPositionManager.sol";
+import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
+import {PositionConfig} from "./shared/PositionConfig.sol";
+import {Planner, Plan} from "./shared/Planner.sol";
+import {Actions} from "../src/libraries/Actions.sol";
+
+contract OwnershipChecksTest is Test, PosmTestSetup {
+    address alice = makeAddr("ALICE");
+    address bob = makeAddr("BOB");
+
+    PositionConfig config;
+    uint256 tokenId;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+        (key,) = initPool(currency0, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1);
+        deployAndApprovePosm(manager);
+        seedBalance(alice);
+        approvePosmFor(alice);
+
+        config = PositionConfig({poolKey: key, tickLower: -300, tickUpper: 300});
+
+        vm.startPrank(alice);
+        mint(config, 100e18, alice, "");
+        vm.stopPrank();
+
+        tokenId = lpm.nextTokenId() - 1;
+    }
+
+    function test_increaseLiquidity_unapproved_reverts() public {
+        bytes memory calls = getIncreaseEncoded(tokenId, config, 1e18, "");
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.NotApproved.selector, bob));
+        vm.prank(bob);
+        lpm.modifyLiquidities(calls, _deadline);
+    }
+
+    function test_decreaseLiquidity_unapproved_reverts() public {
+        bytes memory calls = getDecreaseEncoded(tokenId, config, 1e18, "");
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.NotApproved.selector, bob));
+        vm.prank(bob);
+        lpm.modifyLiquidities(calls, _deadline);
+    }
+
+    function test_collectFees_unapproved_reverts() public {
+        donateRouter.donate(key, 1e18, 1e18, "");
+        bytes memory calls = getCollectEncoded(tokenId, config, "");
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.NotApproved.selector, bob));
+        vm.prank(bob);
+        lpm.modifyLiquidities(calls, _deadline);
+    }
+
+    function test_burn_unapproved_reverts() public {
+        bytes memory calls = getBurnEncoded(tokenId, config, "");
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.NotApproved.selector, bob));
+        vm.prank(bob);
+        lpm.modifyLiquidities(calls, _deadline);
+    }
+
+    function test_modifyLiquiditiesWithoutUnlock_unapproved_reverts() public {
+        Plan memory planner = Planner.init();
+        planner = planner.add(
+            Actions.INCREASE_LIQUIDITY, abi.encode(tokenId, 1e18, MAX_SLIPPAGE_INCREASE, MAX_SLIPPAGE_INCREASE, "")
+        );
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.NotApproved.selector, bob));
+        vm.prank(bob);
+        lpm.modifyLiquiditiesWithoutUnlock(planner.actions, planner.params);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests verifying unauthorized calls revert
- document results in new report

## Testing
- `forge test -vvv --match-path test/OwnershipChecks.t.sol --fuzz-runs 256`


------
https://chatgpt.com/codex/tasks/task_e_685b9b3a23d8832d8801354ddf49f64a