### PR TITLE
Add regression test for slippage fee bypass

### DIFF
--- a/reports/report-20250625-2111-slippage-add-bypass.md
+++ b/reports/report-20250625-2111-slippage-add-bypass.md
@@ -1,0 +1,15 @@
+# Slippage Check Bypass on Liquidity Increase
+
+## Summary
+We analyzed whether accrued fees allow users to bypass `validateMaxIn` when increasing liquidity. The `PositionManager` subtracts fees from the liquidity delta before calling `validateMaxIn`, ensuring the check uses the principal delta only:
+```
+(liquidityDelta - feesAccrued).validateMaxIn(amount0Max, amount1Max);
+```
+## Methodology
+A dedicated test (`SlippageAddBypassTest`) mints a position, donates fees exceeding the deposit, and attempts to increase liquidity with a tight slippage limit. The call is expected to revert with `MaximumAmountExceeded`.
+
+## Findings
+Running `forge test --match-path test/SlippageAddBypass.t.sol --fuzz-runs 512` shows the revert occurs consistently, confirming slippage protection is enforced even when fees exceed the required deposit.
+
+## Conclusion
+At current HEAD the bypass described in earlier audits no longer exists. The slippage guard correctly accounts for accrued fees, preventing frontrunners from extracting value via positive principal deltas.

--- a/test/SlippageAddBypass.t.sol
+++ b/test/SlippageAddBypass.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {LiquidityAmounts} from "@uniswap/v4-core/test/utils/LiquidityAmounts.sol";
+
+import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
+import {PositionConfig} from "./shared/PositionConfig.sol";
+import {ActionConstants} from "../src/libraries/ActionConstants.sol";
+import {Actions} from "../src/libraries/Actions.sol";
+import {Planner} from "./shared/Planner.sol";
+import {SlippageCheck} from "../src/libraries/SlippageCheck.sol";
+
+contract SlippageAddBypassTest is Test, PosmTestSetup {
+    PositionConfig config;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+        deployPosmHookSavesDelta();
+
+        (key,) = initPool(currency0, currency1, IHooks(hook), 3000, SQRT_PRICE_1_1);
+
+        deployAndApprovePosm(manager);
+        seedBalance(address(this));
+        approvePosm();
+
+        config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
+    }
+
+    function test_feesExceedDeposit_slippageStillChecked() public {
+        uint256 tokenId = lpm.nextTokenId();
+        mint(config, 100e18, ActionConstants.MSG_SENDER, ZERO_BYTES);
+
+        uint256 donateAmount = 20e18;
+        donateRouter.donate(key, donateAmount, donateAmount, ZERO_BYTES);
+
+        uint128 newLiquidity = 10e18;
+        (uint256 amount0,) = LiquidityAmounts.getAmountsForLiquidity(
+            SQRT_PRICE_1_1,
+            TickMath.getSqrtPriceAtTick(config.tickLower),
+            TickMath.getSqrtPriceAtTick(config.tickUpper),
+            newLiquidity
+        );
+
+        bytes memory calls = getIncreaseEncoded(tokenId, config, newLiquidity, 1 wei, 1 wei, ZERO_BYTES);
+        vm.expectRevert(
+            abi.encodeWithSelector(SlippageCheck.MaximumAmountExceeded.selector, 1 wei, amount0 + 1)
+        );
+        lpm.modifyLiquidities(calls, _deadline);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `SlippageAddBypassTest` verifying fees do not bypass `validateMaxIn`
- document findings in `reports/report-20250625-2111-slippage-add-bypass.md`

## Testing
- `forge test -vvv --match-path test/SlippageAddBypass.t.sol --fuzz-runs 512`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685c630e7b0c832db37899e8f101d84c