### PR TITLE
Add tests for deployment scripts

### DIFF
--- a/reports/report-DeployScripts-20250625-1.md
+++ b/reports/report-DeployScripts-20250625-1.md
@@ -1,0 +1,21 @@
+# Deployment Scripts Coverage
+
+## Summary
+This report documents additional tests written to exercise the deployment helper scripts within the periphery repository. These scripts previously had zero coverage.
+
+## Test Methodology
+- Reviewed coverage output and found `script/DeployPosm.s.sol`, `DeployStateView.s.sol`, and `DeployV4Quoter.s.sol` reporting 0% coverage.
+- Created a dedicated test contract `DeployScriptsTest` that instantiates each script contract and invokes its `run` function using dummy addresses.
+- Verified that the returned contract instances reference the supplied `poolManager` address.
+
+## Test Steps
+- **test_runDeployPosm**: calls `DeployPosmTest.run` with constant parameters and asserts that the created `PositionManager` and `PositionDescriptor` report the provided pool manager.
+- **test_runDeployStateView**: calls `DeployStateView.run` and checks the deployed `StateView`.
+- **test_runDeployV4Quoter**: calls `DeployV4Quoter.run` and validates the resulting `V4Quoter`.
+
+## Findings
+- All new tests passed, confirming the scripts deploy contracts correctly when called from solidity.
+- No logic flaws were found; however, the added tests raise coverage of these scripts from 0%.
+
+## Conclusion
+The deployment scripts now have direct unit tests confirming their runtime behavior. While no defects were discovered, the repository gains broader coverage of previously untested code paths.

--- a/test/DeployScripts.t.sol
+++ b/test/DeployScripts.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {DeployPosmTest} from "../script/DeployPosm.s.sol";
+import {DeployStateView} from "../script/DeployStateView.s.sol";
+import {DeployV4Quoter} from "../script/DeployV4Quoter.s.sol";
+
+import {IPositionManager} from "../src/interfaces/IPositionManager.sol";
+import {IPositionDescriptor} from "../src/interfaces/IPositionDescriptor.sol";
+import {IStateView} from "../src/interfaces/IStateView.sol";
+import {IV4Quoter} from "../src/interfaces/IV4Quoter.sol";
+
+contract DeployScriptsTest is Test {
+    DeployPosmTest private posmScript;
+    DeployStateView private stateScript;
+    DeployV4Quoter private quoterScript;
+
+    address private constant POOL_MANAGER = address(0x1234);
+    address private constant PERMIT2 = address(0x5678);
+    uint256 private constant GAS_LIMIT = 500000;
+    address private constant WRAPPED_NATIVE = address(0x9abc);
+    bytes32 private constant LABEL_BYTES = bytes32("ETH");
+
+    function setUp() public {
+        posmScript = new DeployPosmTest();
+        stateScript = new DeployStateView();
+        quoterScript = new DeployV4Quoter();
+    }
+
+    function test_runDeployPosm() public {
+        (IPositionDescriptor desc, IPositionManager manager) =
+            posmScript.run(POOL_MANAGER, PERMIT2, GAS_LIMIT, WRAPPED_NATIVE, LABEL_BYTES);
+
+        assertEq(address(manager.poolManager()), POOL_MANAGER);
+        assertEq(address(desc.poolManager()), POOL_MANAGER);
+    }
+
+    function test_runDeployStateView() public {
+        IStateView state = stateScript.run(POOL_MANAGER);
+        assertEq(address(state.poolManager()), POOL_MANAGER);
+    }
+
+    function test_runDeployV4Quoter() public {
+        IV4Quoter quoter = quoterScript.run(POOL_MANAGER);
+        assertEq(address(quoter.poolManager()), POOL_MANAGER);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests exercising DeployPosm, DeployStateView and DeployV4Quoter scripts
- document the new tests in a report

## Testing
- `forge test`


------
https://chatgpt.com/codex/tasks/task_e_685da1e0f830832d9bae58ebc2ada4ae