### PR TITLE
Add router unsupported action test

### DIFF
--- a/reports/report-router-unsupported-action-20250626-2001.md
+++ b/reports/report-router-unsupported-action-20250626-2001.md
@@ -1,0 +1,19 @@
+# Router Unsupported Action Test
+
+This report documents testing for the Uniswap v4 router's handling of unsupported action codes.
+
+## Test Methodology
+- Reviewed existing coverage and found no explicit test that verifies `V4Router` reverts when passed an undefined action.
+- Created a new test `V4RouterUnsupportedAction.t.sol` that builds an actions plan with action `0xff` and expects the router to revert with `BaseActionsRouter.UnsupportedAction`.
+
+## Test Steps
+1. Deploy a fresh pool manager and router with liquidity using `setupRouterCurrenciesAndPoolsWithLiquidity()`.
+2. Build a `Planner` with an unsupported action `0xff` and no parameters.
+3. Call `router.executeActions` with this plan.
+4. Assert that the call reverts with `UnsupportedAction`.
+
+## Findings
+- The new test `test_executeActions_unsupportedAction_reverts` passes, confirming the router properly rejects invalid actions.
+
+## Conclusion
+The router's handling of unsupported actions behaves as expected. This test extends coverage to an edge case previously untested directly on `V4Router`.

--- a/test/router/V4RouterUnsupportedAction.t.sol
+++ b/test/router/V4RouterUnsupportedAction.t.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import {RoutingTestHelpers} from "../shared/RoutingTestHelpers.sol";
+import {Planner} from "../shared/Planner.sol";
+import {BaseActionsRouter} from "../../src/base/BaseActionsRouter.sol";
+
+contract V4RouterUnsupportedActionTest is RoutingTestHelpers {
+    function setUp() public {
+        setupRouterCurrenciesAndPoolsWithLiquidity();
+        plan = Planner.init();
+    }
+
+    function test_executeActions_unsupportedAction_reverts() public {
+        plan = plan.add(0xff, "");
+        vm.expectRevert(
+            abi.encodeWithSelector(BaseActionsRouter.UnsupportedAction.selector, uint256(0xff))
+        );
+        router.executeActions(plan.encode());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for unsupported action on router
- document the test in a new report

## Testing
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685da1e0f830832d9bae58ebc2ada4ae