### PR TITLE
Add gas limit test for Notifier unsubscribe

### DIFF
--- a/reports/report-unsubscribe-gas-limit-20250626.md
+++ b/reports/report-unsubscribe-gas-limit-20250626.md
@@ -1,0 +1,21 @@
+# Unsubscribe Gas Limit Verification
+
+This report documents testing around the `Notifier` unsubscribe gas limit checks.
+
+## Test Methodology
+- Focused on `Notifier._unsubscribe` which reverts with `GasLimitTooLow` if remaining gas is below `unsubscribeGasLimit`.
+- Added a unit test in `NotifierHarness.t.sol` to subscribe a token and then call `_unsubscribe` with insufficient gas.
+- Asserted that the call reverts and the subscriber mapping remains unchanged.
+
+## Test Steps
+- Deploy `NotifierHarness` with gas limit 100000.
+- Subscribe token ID 5 to `SimpleSubscriber`.
+- Call `unsubscribeWrap` with `gas = unsubscribeGasLimit - 1` expecting `GasLimitTooLow` revert.
+- Verify subscriber address remains stored.
+
+## Findings
+- The new test passed confirming the revert occurs as expected when gas is insufficient.
+- No unexpected behavior observed; existing logic handles low gas properly.
+
+## Conclusion
+The added test covers a previously untested edge in `Notifier` ensuring gas limit enforcement. The unsubscribe mechanism functions correctly under constrained gas.

--- a/test/NotifierHarness.t.sol
+++ b/test/NotifierHarness.t.sol
@@ -34,6 +34,15 @@ contract NotifierHarnessTest is Test {
         assertEq(sub.unsubscribeCount(), 1);
     }
 
+    function test_unsubscribe_gas_limit_reverts() public {
+        SimpleSubscriber sub = new SimpleSubscriber();
+        harness.subscribe(5, address(sub), "");
+        uint256 gasLimit = harness.unsubscribeGasLimit();
+        vm.expectRevert(INotifier.GasLimitTooLow.selector);
+        harness.unsubscribeWrap{gas: gasLimit - 1}(5);
+        assertEq(address(harness.subscriber(5)), address(sub));
+    }
+
     function test_callWrap_success() public {
         SimpleSubscriber sub = new SimpleSubscriber();
         bytes memory data = abi.encodeCall(ISubscriber.notifySubscribe, (1, ""));


### PR DESCRIPTION
## Summary
- check Notifier unsubscribe gas cap
- document the test results

## Testing
- `forge test -vvv`


------
https://chatgpt.com/codex/tasks/task_e_685da1e0f830832d9bae58ebc2ada4ae