### PR TITLE
Add coverage for getPoolAndPositionInfo

### DIFF
--- a/reports/report-getPoolAndPositionInfo-20250626-01.md
+++ b/reports/report-getPoolAndPositionInfo-20250626-01.md
@@ -1,0 +1,18 @@
+# getPoolAndPositionInfo getter coverage
+
+## Summary
+Added a new test to verify `PositionManager.getPoolAndPositionInfo` returns the correct `PoolKey` and `PositionInfo` for a freshly minted position. Previous tests did not exercise this getter at all.
+
+## Test Methodology
+- Deploy a fresh pool manager and two ERC20 tokens via `PosmTestSetup`.
+- Initialize a pool and deploy the `PositionManager`.
+- Mint a single liquidity position and capture the resulting token ID.
+- Call `getPoolAndPositionInfo` and validate all fields match the originally minted configuration.
+- Ensure reported liquidity via `getPositionLiquidity` equals the minted liquidity.
+
+## Findings
+- The getter returned the correct pool data and position ticks, confirming expected behaviour.
+- No bugs were uncovered; test provides missing coverage for this public view function.
+
+## Conclusion
+The new test closes a small coverage gap by exercising `getPoolAndPositionInfo`. All tests continue to pass, indicating consistent behaviour.

--- a/test/position-managers/GetPoolAndPositionInfo.t.sol
+++ b/test/position-managers/GetPoolAndPositionInfo.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PositionInfo} from "../../src/libraries/PositionInfoLibrary.sol";
+import {PositionConfig} from "../shared/PositionConfig.sol";
+import {PosmTestSetup} from "../shared/PosmTestSetup.sol";
+
+contract GetPoolAndPositionInfoTest is Test, PosmTestSetup {
+    PoolId poolId;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+        (key, poolId) = initPool(currency0, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1);
+        deployAndApprovePosm(manager);
+    }
+
+    function test_getPoolAndPositionInfo_returns_pool_and_position() public {
+        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -key.tickSpacing, tickUpper: key.tickSpacing});
+        uint256 liquidity = 1e18;
+        mint(config, liquidity, address(this), "");
+        uint256 tokenId = lpm.nextTokenId() - 1;
+
+        (PoolKey memory returnedKey, PositionInfo info) = lpm.getPoolAndPositionInfo(tokenId);
+
+        assertEq(Currency.unwrap(returnedKey.currency0), Currency.unwrap(key.currency0));
+        assertEq(Currency.unwrap(returnedKey.currency1), Currency.unwrap(key.currency1));
+        assertEq(returnedKey.fee, key.fee);
+        assertEq(returnedKey.tickSpacing, key.tickSpacing);
+        assertEq(address(returnedKey.hooks), address(key.hooks));
+        assertEq(info.tickLower(), config.tickLower);
+        assertEq(info.tickUpper(), config.tickUpper);
+        assertEq(bytes25(info.poolId()), bytes25(PoolId.unwrap(poolId)));
+
+        uint128 returnedLiquidity = lpm.getPositionLiquidity(tokenId);
+        assertEq(returnedLiquidity, liquidity);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add test for PositionManager.getPoolAndPositionInfo
- document new test in reports

## Testing
- `FOUNDRY_PROFILE=debug forge test --match-test getPoolAndPositionInfo_returns_pool_and_position -vv`
- `FOUNDRY_PROFILE=debug forge test -vv`

------
https://chatgpt.com/codex/tasks/task_e_685db40ad54c832da62dc7ba09b404fc