### PR TITLE
Add HookMiner computeAddress test

### DIFF
--- a/reports/report-HookMiner-computeAddress-20250627.md
+++ b/reports/report-HookMiner-computeAddress-20250627.md
@@ -1,0 +1,19 @@
+# HookMiner computeAddress Coverage
+
+## Summary
+Added a unit test verifying that `HookMiner.computeAddress` matches OpenZeppelin's `Create2.computeAddress` formula.
+
+## Test Methodology
+- Constructed bytecode using `MockBlankHook` creation code with constructor arguments.
+- Called `HookMiner.computeAddress` and compared it with `Create2.computeAddress` using the same deployer and salt.
+
+## Test Steps
+1. Build bytecode with constructor parameters.
+2. Compute expected address using `Create2.computeAddress`.
+3. Assert `HookMiner.computeAddress` returns the same address.
+
+## Findings
+- The new test passed, confirming the correctness of `HookMiner.computeAddress`.
+
+## Conclusion
+This test adds explicit coverage for `HookMiner`'s `computeAddress` helper which previously lacked direct verification.

--- a/test/libraries/HookMinerComputeAddress.t.sol
+++ b/test/libraries/HookMinerComputeAddress.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+import {HookMiner} from "../../src/utils/HookMiner.sol";
+import {MockBlankHook} from "../mocks/MockBlankHook.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+contract HookMinerComputeAddressTest is Test {
+    function test_computeAddress_matches_create2() public {
+        address deployer = address(this);
+        bytes memory bytecode = abi.encodePacked(
+            type(MockBlankHook).creationCode,
+            abi.encode(IPoolManager(address(0)), uint256(123), uint16(0))
+        );
+        uint256 salt = 12345;
+        address expected = Create2.computeAddress(bytes32(salt), keccak256(bytecode), deployer);
+        address result = HookMiner.computeAddress(deployer, salt, bytecode);
+        assertEq(result, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- add test verifying HookMiner.computeAddress formula
- document coverage in report

## Testing
- `forge test -vvv test/libraries/HookMinerComputeAddress.t.sol`
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685dfd5325ac832daa7d15f60432889d