### PR TITLE
Add zero amount test for DeltaResolver

### DIFF
--- a/reports/report-DeltaResolverTakeZero-20250627.md
+++ b/reports/report-DeltaResolverTakeZero-20250627.md
@@ -1,0 +1,25 @@
+# DeltaResolver zero _take coverage
+
+## Summary
+This report documents the execution of the test suite for the Uniswap v4 periphery and the creation of an additional test covering the edge case where `DeltaResolver._take` is called with amount `0`. All existing tests pass and the new test verifies that the pool manager is not invoked when taking zero currency.
+
+## Test Methodology
+- Ran the full Foundry test suite using `forge test`.
+- Attempted to gather coverage with `forge coverage` but reports showed zero coverage due to configuration limitations.
+- Searched the repository for areas with minimal explicit tests. The `_take` function in `DeltaResolver` returns early for amount `0` and no test ensured this behaviour.
+- Implemented a harness and mock pool manager to record calls.
+
+## Test Steps
+- Added `test/DeltaResolverTakeZero.t.sol` which:
+  - Deploys `MockPoolManagerTakeZero` recording `take` calls.
+  - Exposes `_take` via `TakeZeroResolverHarness`.
+  - Asserts that calling with amount `0` leaves `takeCallCount` unchanged.
+  - Asserts that non‑zero amounts increment the counter.
+- Executed `forge test` confirming all 652 tests including the new ones pass.
+
+## Findings
+- The new test succeeded, demonstrating `_take` correctly skips pool manager interaction when the amount is `0`.
+- No unexpected failures were observed. The added test is non‑redundant and closes a small coverage gap around `_take`.
+
+## Conclusion
+All existing tests continue to pass and the added test improves assurance around `DeltaResolver`'s handling of zero amounts. Coverage tooling could not be fully executed due to environment constraints, but manual inspection indicated this edge case lacked explicit tests and is now verified.

--- a/test/DeltaResolverTakeZero.t.sol
+++ b/test/DeltaResolverTakeZero.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {DeltaResolver} from "../src/base/DeltaResolver.sol";
+import {ImmutableState} from "../src/base/ImmutableState.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+contract MockPoolManagerTakeZero {
+    uint256 public takeCallCount;
+
+    function currencyDelta(address, Currency) external view returns (int256) {
+        return 0;
+    }
+
+    function exttload(bytes32) external view returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function sync(Currency) external {}
+    function settle() external payable {}
+
+    function take(Currency, address, uint256) external {
+        takeCallCount++;
+    }
+}
+
+contract TakeZeroResolverHarness is DeltaResolver {
+    constructor(MockPoolManagerTakeZero manager)
+        ImmutableState(IPoolManager(address(manager)))
+    {}
+
+    function expose_take(Currency currency, address recipient, uint256 amount) external {
+        _take(currency, recipient, amount);
+    }
+
+    function _pay(Currency, address, uint256) internal override {}
+}
+
+contract DeltaResolverTakeZeroTest is Test {
+    MockPoolManagerTakeZero manager;
+    TakeZeroResolverHarness resolver;
+    Currency token;
+
+    function setUp() public {
+        manager = new MockPoolManagerTakeZero();
+        resolver = new TakeZeroResolverHarness(manager);
+        token = Currency.wrap(address(0x1234));
+    }
+
+    function test_take_zero_no_call() public {
+        resolver.expose_take(token, address(0x1), 0);
+        assertEq(manager.takeCallCount(), 0);
+    }
+
+    function test_take_nonzero_calls_poolManager() public {
+        resolver.expose_take(token, address(0x1), 5);
+        assertEq(manager.takeCallCount(), 1);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add targeted test ensuring DeltaResolver `_take` skips PoolManager when amount is zero
- document test results in new report

## Testing
- `forge test`


------
https://chatgpt.com/codex/tasks/task_e_685e1631d838832da167c69128a292bc