### PR TITLE
Add support flag harness tests

### DIFF
--- a/reports/report-hook-supports-20250627-0416.md
+++ b/reports/report-hook-supports-20250627-0416.md
@@ -1,0 +1,19 @@
+# Hook support flags coverage
+
+## Summary
+Added tests to verify that token wrapper hooks expose correct support flags for exact input/output swaps.
+
+## Test Methodology
+- Created harness contracts overriding `validateHookAddress` to allow direct deployment and exposing `_supportsExactInput` and `_supportsExactOutput`.
+- WETHHook harness checks default behavior; WstETHHook harness checks override.
+
+## Test Steps
+- Deploy harness hooks in tests.
+- Call `supportsExactInput` and `supportsExactOutput` and assert expected booleans.
+
+## Findings
+- WETHHook supports both exact input and exact output.
+- WstETHHook only supports exact input as expected.
+
+## Conclusion
+New tests confirm hook support flags behave as designed, covering internal methods previously untested.

--- a/test/harness/WETHHookHarness.sol
+++ b/test/harness/WETHHookHarness.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {WETHHook} from "../../src/hooks/WETHHook.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+import {BaseHook} from "../../src/utils/BaseHook.sol";
+
+/// @dev Harness exposing internal view functions for testing
+contract WETHHookHarness is WETHHook {
+    constructor(IPoolManager _manager, WETH _weth) WETHHook(_manager, payable(address(_weth))) {}
+
+    function validateHookAddress(BaseHook) internal pure override {}
+
+    function supportsExactOutput() external view returns (bool) {
+        return _supportsExactOutput();
+    }
+
+    function supportsExactInput() external view returns (bool) {
+        return _supportsExactInput();
+    }
+}

--- a/test/harness/WstETHHookHarness.sol
+++ b/test/harness/WstETHHookHarness.sol
@@ -3,10 +3,13 @@ pragma solidity ^0.8.24;
 import {WstETHHook} from "../../src/hooks/WstETHHook.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IWstETH} from "../../src/interfaces/external/IWstETH.sol";
+import {BaseHook} from "../../src/utils/BaseHook.sol";
 
 /// @dev Harness exposing internal view functions for testing
 contract WstETHHookHarness is WstETHHook {
     constructor(IPoolManager _manager, IWstETH _wsteth) WstETHHook(_manager, _wsteth) {}
+
+    function validateHookAddress(BaseHook) internal pure override {}
 
     function getWrapInputRequired(uint256 amount) external view returns (uint256) {
         return _getWrapInputRequired(amount);
@@ -14,5 +17,13 @@ contract WstETHHookHarness is WstETHHook {
 
     function getUnwrapInputRequired(uint256 amount) external view returns (uint256) {
         return _getUnwrapInputRequired(amount);
+    }
+
+    function supportsExactOutput() external view returns (bool) {
+        return _supportsExactOutput();
+    }
+
+    function supportsExactInput() external view returns (bool) {
+        return _supportsExactInput();
     }
 }

--- a/test/hooks/WETHHookSupports.t.sol
+++ b/test/hooks/WETHHookSupports.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {WETHHookHarness} from "../harness/WETHHookHarness.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+
+contract WETHHookSupportsTest is Test, Deployers {
+    WETHHookHarness public hook;
+    WETH public weth;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        weth = new WETH();
+        hook = new WETHHookHarness(manager, weth);
+    }
+
+    function test_support_flags() public {
+        assertTrue(hook.supportsExactInput());
+        assertTrue(hook.supportsExactOutput());
+    }
+}

--- a/test/hooks/WstETHHookSupports.t.sol
+++ b/test/hooks/WstETHHookSupports.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {WstETHHookHarness} from "../harness/WstETHHookHarness.sol";
+import {MockWstETH} from "../mocks/MockWstETH.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+
+contract WstETHHookSupportsTest is Test, Deployers {
+    WstETHHookHarness public hook;
+    MockWstETH public wstETH;
+    MockERC20 public stETH;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        stETH = new MockERC20("stETH", "STETH", 18);
+        wstETH = new MockWstETH(address(stETH));
+        hook = new WstETHHookHarness(manager, wstETH);
+    }
+
+    function test_support_flags() public {
+        assertTrue(hook.supportsExactInput());
+        assertFalse(hook.supportsExactOutput());
+    }
+}


### PR DESCRIPTION
## Summary
- add harness for WETHHook and expose support flag helpers
- expose same helpers in WstETHHook harness
- unit tests assert expected support for exact input/output
- document test approach

## Testing
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685e161f6868832d8356ffdf69e0cfc3