### PR TITLE
Add hex letter coverage test

### DIFF
--- a/reports/report-AddressStringUtil-letters-20250627-0419.md
+++ b/reports/report-AddressStringUtil-letters-20250627-0419.md
@@ -1,0 +1,19 @@
+# AddressStringUtil Hex Letter Coverage
+
+## Summary
+Added a unit test targeting `AddressStringUtil.toAsciiString` when converting bytes containing hex letters to ensure uppercase output. All existing tests pass after the addition.
+
+## Test Methodology
+- Inspected coverage report and identified low coverage for `AddressStringUtil.sol`.
+- Wrote a focused test `test_toAsciiString_hexLetters` verifying conversion of an address beginning with `0xabcd...` to a 4-character string.
+
+## Test Steps
+- Call `AddressStringUtil.toAsciiString` with a checksummed address `0xaBcDEf0000000000000000000000000000000000` and length `4`.
+- Assert the returned string equals `"ABCD"`.
+
+## Findings
+- The new test passed and confirmed uppercase hex output.
+- No code changes were required beyond the new test.
+
+## Conclusion
+The additional test improves coverage for `AddressStringUtil`'s handling of hex letters. No functional issues were discovered.

--- a/test/libraries/AddressStringUtilEdge.t.sol
+++ b/test/libraries/AddressStringUtilEdge.t.sol
@@ -28,4 +28,10 @@ contract AddressStringUtilEdgeTest is Test {
         assertEq(b[0], charRef(byteVal >> 4));
         assertEq(b[1], charRef(byteVal & 0xf));
     }
+
+    function test_toAsciiString_hexLetters() public {
+        address addr = address(0xaBcDEf0000000000000000000000000000000000);
+        string memory s = AddressStringUtil.toAsciiString(addr, 4);
+        assertEq(s, "ABCD");
+    }
 }


### PR DESCRIPTION
## Summary
- test AddressStringUtil uppercase output
- document rationale in new report

## Testing
- `forge test --match-contract AddressStringUtilEdgeTest -vvv`
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685e1631d838832da167c69128a292bc