### PR TITLE
Add nibble bounds test

### DIFF
--- a/reports/report-VanityNibbleOOB-20250627.md
+++ b/reports/report-VanityNibbleOOB-20250627.md
@@ -1,0 +1,18 @@
+# VanityAddressLib nibble bounds test
+
+## Summary
+Added a new unit test that ensures `VanityAddressLib.getNibble` reverts with a panic when the nibble index exceeds the 40‑nibble length of an address.
+
+## Test Methodology
+The existing edge suite did not cover out-of-bounds indices for `getNibble`. A harness contract exposes the library call and the test expects `stdError.indexOOBError` on index `40`.
+
+## Test Steps
+- Deploy `VanityAddressLibEdgeHarness` in `setUp`.
+- Call `getNibble` with a sample address and index `40` while expecting a revert.
+- Confirm normal nibble extraction continues to work for valid indices.
+
+## Findings
+The new test passed and triggered the expected revert, proving the library safely fails on invalid indices. No code changes were required.
+
+## Conclusion
+This test fills a small gap in `VanityAddressLibEdge` coverage by exercising the out‑of‑bounds branch of `getNibble`.

--- a/test/libraries/VanityAddressLibEdge.t.sol
+++ b/test/libraries/VanityAddressLibEdge.t.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import {Test} from "forge-std/Test.sol";
+import "forge-std/Test.sol";
+import {stdError} from "forge-std/StdError.sol";
 import {VanityAddressLib} from "../../src/libraries/VanityAddressLib.sol";
 
 contract VanityAddressLibEdgeHarness {
@@ -35,5 +36,11 @@ contract VanityAddressLibEdgeTest is Test {
         assertEq(harness.getNibble(sample, 3), 0x4);
         assertEq(harness.getNibble(sample, 38), 0x7);
         assertEq(harness.getNibble(sample, 39), 0x8);
+    }
+
+    function test_getNibble_outOfBounds() public {
+        bytes20 sample = bytes20(0x1234567890AbcdEF1234567890aBcdef12345678);
+        vm.expectRevert(stdError.indexOOBError);
+        harness.getNibble(sample, 40);
     }
 }


### PR DESCRIPTION
## Summary
- expand `VanityAddressLibEdge` tests with out-of-bounds check
- document the new coverage

## Testing
- `forge test --match-contract VanityAddressLibEdgeTest -vv`
- `forge test -q`

------
https://chatgpt.com/codex/tasks/task_e_685e161f6868832d8356ffdf69e0cfc3