### PR TITLE
Add invalid offset test for CalldataDecoder

### DIFF
--- a/reports/report-CalldataDecoderInvalidOffset-20250627.md
+++ b/reports/report-CalldataDecoderInvalidOffset-20250627.md
@@ -1,0 +1,21 @@
+# CalldataDecoder Invalid Offset Coverage
+
+## Summary
+Added a test ensuring `decodeActionsRouterParams` reverts when the encoded parameter offsets do not follow strict ABI rules. This covers a failure mode previously untested.
+
+## Test Methodology
+- Constructed standard encoded calldata for `(bytes, bytes[])`.
+- Mutated the first offset so it no longer points to the `actions` length.
+- Expected `SliceOutOfBounds` revert when decoding.
+
+## Test Steps
+- `CalldataDecoderInvalidOffsetTest.test_decodeActionsRouterParams_invalidOffset_reverts`
+  - Encodes one action with a single parameter.
+  - Overwrites the first word with an invalid value.
+  - Calls `decoder.decodeActionsRouterParams` expecting a revert.
+
+## Findings
+- The decoder correctly reverted with `SliceOutOfBounds`, confirming strict encoding checks.
+
+## Conclusion
+This additional test increases branch coverage in `CalldataDecoder` by exercising an error path for malformed offsets.

--- a/test/libraries/CalldataDecoderInvalidOffset.t.sol
+++ b/test/libraries/CalldataDecoderInvalidOffset.t.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {MockCalldataDecoder} from "../mocks/MockCalldataDecoder.sol";
+import {CalldataDecoder} from "../../src/libraries/CalldataDecoder.sol";
+
+contract CalldataDecoderInvalidOffsetTest is Test {
+    MockCalldataDecoder decoder;
+
+    function setUp() public {
+        decoder = new MockCalldataDecoder();
+    }
+
+    function test_decodeActionsRouterParams_invalidOffset_reverts() public {
+        bytes memory actions = hex"01";
+        bytes[] memory params = new bytes[](1);
+        params[0] = hex"abcd";
+        bytes memory data = abi.encode(actions, params);
+
+        // Corrupt the first offset word expected to be 0x40
+        assembly {
+            mstore(add(data, 0x20), 0x41)
+        }
+
+        vm.expectRevert(CalldataDecoder.SliceOutOfBounds.selector);
+        decoder.decodeActionsRouterParams(data);
+    }
+}


### PR DESCRIPTION
## Summary
- test `decodeActionsRouterParams` with malformed offset to improve coverage
- document behaviour in a new report

## Testing
- `forge test`
- `forge coverage --report summary`

------
https://chatgpt.com/codex/tasks/task_e_685e1631d838832da167c69128a292bc