### PR TITLE
Add AddressStringUtil edge case tests

### DIFF
--- a/reports/report-addressstringutil-20250627-01.md
+++ b/reports/report-addressstringutil-20250627-01.md
@@ -1,0 +1,19 @@
+# AddressStringUtil Revert Handling Tests
+
+## Summary
+New unit tests verify `AddressStringUtil.toAsciiString` rejects zero length and overly long requests while returning the expected 40-character output for a full address.
+
+## Methodology
+- Inspected coverage data and saw `AddressStringUtil.sol` around 56% coverage.
+- Created `AddressStringUtilMoreTest` to trigger edge cases not covered before.
+
+## Test Steps
+- `test_invalid_length_zero` expects revert when length is zero.
+- `test_invalid_length_too_big` expects revert for length > 40.
+- `test_full_length_output` checks a known address converts to 40-char hex.
+
+## Findings
+All tests passed and coverage improved slightly for `AddressStringUtil`.
+
+## Conclusion
+Edge case validation around address-to-string conversion now has explicit tests ensuring proper error handling.

--- a/test/libraries/AddressStringUtilMore.t.sol
+++ b/test/libraries/AddressStringUtilMore.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {AddressStringUtil} from "../../src/libraries/AddressStringUtil.sol";
+
+contract AddressStringUtilMoreTest is Test {
+    function _call(address a, uint256 len) external pure returns (string memory) {
+        return AddressStringUtil.toAsciiString(a, len);
+    }
+
+    function test_invalid_length_zero() public {
+        vm.expectRevert(abi.encodeWithSelector(AddressStringUtil.InvalidAddressLength.selector, 0));
+        this._call(address(0x1234), 0);
+    }
+
+    function test_invalid_length_too_big() public {
+        vm.expectRevert(abi.encodeWithSelector(AddressStringUtil.InvalidAddressLength.selector, 42));
+        this._call(address(0x1234), 42);
+    }
+
+    function test_full_length_output() public {
+        address addr = 0x1234567890123456789012345678901234567890;
+        string memory s = AddressStringUtil.toAsciiString(addr, 40);
+        assertEq(s, "1234567890123456789012345678901234567890");
+    }
+}


### PR DESCRIPTION
## Summary
- add AddressStringUtilMoreTest covering invalid lengths and full address output
- document the new tests

## Testing
- `forge test --match-path test/libraries/AddressStringUtilMore.t.sol`
- `forge test`
- `forge coverage --report summary`


------
https://chatgpt.com/codex/tasks/task_e_685e1631d838832da167c69128a292bc