### PR TITLE
Add short-selector test for QuoterRevert

### DIFF
--- a/reports/report-QuoterRevertShortSelector-20250627-0615.md
+++ b/reports/report-QuoterRevertShortSelector-20250627-0615.md
@@ -1,0 +1,23 @@
+# QuoterRevert Short Selector Handling
+
+## Summary
+This test checks how `QuoterRevert.parseQuoteAmount` handles revert data that only
+contains the `QuoteSwap` selector. The library returns `0` instead of reverting.
+
+## Test Methodology
+- Created `QuoterRevertEdgeShort.t.sol` with a wrapper contract exposing the
+  parsing function.
+- Passed revert bytes with only the selector and no encoded `uint256` amount.
+
+## Test Steps
+- Deploy wrapper and call `callParse` with `abi.encodePacked(QuoteSwap.selector)`.
+- Assert the returned value equals zero.
+
+## Findings
+- The library does not validate the length of the revert data and returns `0`
+  when the encoded amount is missing. No revert is thrown.
+
+## Conclusion
+`QuoterRevert.parseQuoteAmount` treats a truncated revert payload as a valid
+quote of zero. Existing tests did not cover this case. The current behavior may
+be acceptable but should be documented if intentional.

--- a/test/libraries/QuoterRevertEdgeShort.t.sol
+++ b/test/libraries/QuoterRevertEdgeShort.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {QuoterRevert} from "../../src/libraries/QuoterRevert.sol";
+
+contract QuoterRevertWrapperShort {
+    function callParse(bytes calldata data) external pure returns (uint256) {
+        return QuoterRevert.parseQuoteAmount(data);
+    }
+}
+
+contract QuoterRevertEdgeShortTest is Test {
+    QuoterRevertWrapperShort wrapper;
+
+    function setUp() public {
+        wrapper = new QuoterRevertWrapperShort();
+    }
+
+    function test_parseQuoteAmount_shortSelector() public {
+        bytes memory data = abi.encodePacked(QuoterRevert.QuoteSwap.selector);
+        uint256 parsed = wrapper.callParse(data);
+        assertEq(parsed, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add QuoterRevertEdgeShort.t.sol checking parseQuoteAmount on truncated data
- document behaviour in a new report

## Testing
- `forge test`


------
https://chatgpt.com/codex/tasks/task_e_685e34ce51f8832d9ab0ac9243396587