### PR TITLE
Add vanity address scoring test

### DIFF
--- a/reports/report-VanityFives-20250627-0628.md
+++ b/reports/report-VanityFives-20250627-0628.md
@@ -1,0 +1,19 @@
+# VanityAddressLib Additional Coverage
+
+## Summary
+Targeted test added to verify scoring for addresses starting with more than four `4` nibbles. Suite continues to pass.
+
+## Test Methodology
+- Reviewed existing tests which covered all zero and mixed nibble cases but lacked a scenario where five leading `4` nibbles appear without being all fours.
+- Crafted a deterministic unit test calculating the score for `0x4444444000000000000000000000000000004444`.
+
+## Test Steps
+- Added `test_scoreLeadingFives` in `VanityAddressLib.t.sol` that asserts the computed score equals `71`.
+- Ran `forge test` to ensure the full suite still passes.
+
+## Findings
+- New test passed confirming correct handling of more than four leading fours.
+- No regressions detected across 662 existing tests.
+
+## Conclusion
+The additional case improves coverage for `VanityAddressLib.score` edge conditions without affecting other functionality.

--- a/test/libraries/VanityAddressLib.t.sol
+++ b/test/libraries/VanityAddressLib.t.sol
@@ -56,6 +56,12 @@ contract VanityAddressLibTest is Test {
         assertEq(score, expected);
     }
 
+    function test_scoreLeadingFives() public pure {
+        address addr = address(0x4444444000000000000000000000000000004444);
+        uint256 score = VanityAddressLib.score(addr);
+        assertEq(score, 71);
+    }
+
     function test_scores_succeed() public pure {
         assertEq(VanityAddressLib.score(address(0x0000000000000000000000000000000000000082)), 0); // 0
         assertEq(VanityAddressLib.score(address(0x0400000000000000000000000000000000000000)), 11); // 10 * 1 + 1 = 11


### PR DESCRIPTION
## Summary
- run full forge tests
- add focused test for VanityAddressLib when 5 fours lead the address
- document results

## Testing
- `forge test --match-test test_scoreLeadingFives -vvv`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685e34ce51f8832d9ab0ac9243396587