### PR TITLE
Add long label test for PositionDescriptor

### DIFF
--- a/reports/report-long-label-test-20250627-01.md
+++ b/reports/report-long-label-test-20250627-01.md
@@ -1,0 +1,20 @@
+# PositionDescriptor long label test
+
+## Summary
+This report documents running the full test suite and adding a targeted test to verify that `PositionDescriptor.nativeCurrencyLabel` correctly handles a 32 byte label.
+
+## Test Methodology
+- Ran existing `forge test` across the repository to establish a baseline.
+- Generated a coverage report for a sample run to inspect coverage metrics.
+- Identified the lack of tests covering maximum length labels in `nativeCurrencyLabel`.
+- Implemented a new unit test `PositionDescriptorLabelLength.t.sol` deploying a descriptor with a 32 byte label and asserting the label is returned intact.
+
+## Test Steps
+- **PositionDescriptorLabelLengthTest** – deploys a `PositionDescriptor` with a 32 byte label and checks `nativeCurrencyLabel()` matches the label string.
+
+## Findings
+- All tests, including the new one, pass successfully. This confirms that long labels are handled as expected.
+- Coverage output for the targeted run indicates low overall coverage when running a single test, but no failures were observed.
+
+## Conclusion
+The Uniswap v4 periphery suite currently passes 663 tests. The new test adds assurance that `PositionDescriptor` properly handles the edge case of maximum length labels.

--- a/test/PositionDescriptorLabelLength.t.sol
+++ b/test/PositionDescriptorLabelLength.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {Deploy} from "./shared/Deploy.sol";
+import {IPositionDescriptor} from "../src/interfaces/IPositionDescriptor.sol";
+import {IWETH9} from "../src/interfaces/external/IWETH9.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+
+contract PositionDescriptorLabelLengthTest is Test, Deployers {
+    IPositionDescriptor descriptor;
+    IWETH9 weth;
+
+    string constant LONG_LABEL = "12345678901234567890123456789012";
+    bytes32 constant LONG_LABEL_BYTES = 0x3132333435363738393031323334353637383930313233343536373839303132;
+
+    function setUp() public {
+        deployFreshManager();
+        weth = IWETH9(address(new WETH()));
+        descriptor = Deploy.positionDescriptor(address(manager), address(weth), LONG_LABEL_BYTES, hex"00");
+    }
+
+    function test_nativeCurrencyLabel_32bytes() public {
+        assertEq(descriptor.nativeCurrencyLabel(), LONG_LABEL);
+    }
+}


### PR DESCRIPTION
## Summary
- run `forge test` as baseline (all suites passed)
- add unit test ensuring `PositionDescriptor.nativeCurrencyLabel` handles 32 byte labels
- document results in new report

## Testing
- `forge test -vv`
- `forge test -vv --match-path test/PositionDescriptorLabelLength.t.sol`
- `forge coverage --match-path test/PositionDescriptorLabelLength.t.sol`

------
https://chatgpt.com/codex/tasks/task_e_685e34ce51f8832d9ab0ac9243396587