### PR TITLE
Add coverage for deployer competition updates

### DIFF
--- a/reports/report-DeployerCompetitionMultipleUpdate-20250627.md
+++ b/reports/report-DeployerCompetitionMultipleUpdate-20250627.md
@@ -1,0 +1,20 @@
+# Deployer competition multi-update
+
+This round adds a regression test ensuring `UniswapV4DeployerCompetition` correctly updates the best address when multiple better salts are submitted sequentially.
+
+## Test Methodology
+- Reviewed existing tests and noticed no scenario covering repeated updates with increasingly better salts.
+- Crafted a deterministic search inside the test to generate salts that produce increasingly better vanity scores using `Create2.computeAddress`.
+- Verified the contract records the best salt and submitter after each update.
+
+## Test Steps
+- `test_updateBestAddress_multiple_updates` loops to find a salt yielding an address better than the default.
+- After calling `updateBestAddress` with that salt, the test searches for another salt with an even higher score.
+- The competition is updated again and assertions confirm the address and submitter fields reflect the better salt.
+
+## Findings
+- The new test passes, demonstrating that repeated updates correctly replace prior best values.
+- No functional bugs were found; the contract handles sequential improvements as intended.
+
+## Conclusion
+Adding coverage for consecutive updates strengthens confidence in the deployer competition logic. No further issues were observed.

--- a/test/UniswapV4DeployerCompetition.t.sol
+++ b/test/UniswapV4DeployerCompetition.t.sol
@@ -175,4 +175,45 @@ contract UniswapV4DeployerCompetitionTest is Test {
         vm.prank(address(1));
         competition.deploy(abi.encodePacked(type(PoolManager).creationCode, uint256(uint160(v4Owner))));
     }
+
+    function test_updateBestAddress_multiple_updates() public {
+        address caller1 = makeAddr("CALLER1");
+        address caller2 = makeAddr("CALLER2");
+
+        bytes32 salt1;
+        address addr1;
+        for (uint256 i = 1; i < 100000; i++) {
+            bytes32 candidate = bytes32((uint256(uint160(caller1)) << 96) | i);
+            address candidateAddr = Create2.computeAddress(candidate, initCodeHash, address(competition));
+            if (candidateAddr.betterThan(defaultAddress)) {
+                salt1 = candidate;
+                addr1 = candidateAddr;
+                break;
+            }
+        }
+        require(addr1 != address(0), "no salt1");
+
+        vm.prank(caller1);
+        competition.updateBestAddress(salt1);
+        assertEq(competition.bestAddress(), addr1);
+
+        bytes32 salt2;
+        address addr2;
+        for (uint256 i = 1; i < 100000; i++) {
+            bytes32 candidate = bytes32((uint256(uint160(caller2)) << 96) | i);
+            address candidateAddr = Create2.computeAddress(candidate, initCodeHash, address(competition));
+            if (candidateAddr.betterThan(addr1)) {
+                salt2 = candidate;
+                addr2 = candidateAddr;
+                break;
+            }
+        }
+        require(addr2 != address(0), "no salt2");
+
+        vm.prank(caller2);
+        competition.updateBestAddress(salt2);
+        assertEq(competition.bestAddress(), addr2);
+        assertEq(competition.bestAddressSubmitter(), caller2);
+        assertEq(competition.bestAddressSalt(), salt2);
+    }
 }


### PR DESCRIPTION
## Summary
- test sequential updates in `UniswapV4DeployerCompetition`
- add coverage report for the new scenario

## Testing
- `forge test --match-test updateBestAddress_multiple_updates -vvvv`


------
https://chatgpt.com/codex/tasks/task_e_685e34b0433c832d8a695a75c58f7357