### PR TITLE
Add WETHHook receive test

### DIFF
--- a/reports/report-WETHHookReceive-20250627.md
+++ b/reports/report-WETHHookReceive-20250627.md
@@ -1,0 +1,22 @@
+# WETHHook Receive Function Test
+
+## Summary
+This report documents additional coverage for the `WETHHook` contract, specifically its ability to accept direct ETH transfers via the `receive()` function. Existing tests covered wrapping and unwrapping flows through the router, but no test ensured that sending ETH directly to the hook succeeded.
+
+## Test Methodology
+A new unit test `WETHHookReceiveTest` deploys `WETHHook` with a pool manager and WETH instance. The test sends 1 ether directly to the hook address using a low-level call and verifies that:
+- the call succeeds (no revert)
+- the hook’s balance increases by the sent amount.
+
+## Test Steps
+- Deploy a fresh pool manager and routers using helper utilities.
+- Deploy WETH and the hook contract.
+- Send 1 ether to the hook using `address(hook).call{value: 1 ether}("")`.
+- Assert the call returned true and the hook’s ETH balance incremented.
+
+## Findings
+- **Outcome:** The test passed, confirming the hook accepts ETH and updates its balance.
+- **Analysis:** While the hook’s receive function is trivial, confirming it behaves as expected adds assurance for integrations that might send ETH directly (e.g., refunds or mis‑routed transfers).
+
+## Conclusion
+No flaws were discovered. The new test fills a minor gap by covering the receive path. All existing tests continue to pass, bringing total suite count to 663 tests.

--- a/test/hooks/WETHHookReceive.t.sol
+++ b/test/hooks/WETHHookReceive.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {WETHHook} from "../../src/hooks/WETHHook.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+
+/// @notice Tests the fallback receive function on WETHHook
+contract WETHHookReceiveTest is Test, Deployers {
+    WETHHook public hook;
+    WETH public weth;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        weth = new WETH();
+        hook = WETHHook(
+            payable(
+                address(
+                    uint160(
+                        type(uint160).max & clearAllHookPermissionsMask |
+                            Hooks.BEFORE_SWAP_FLAG |
+                            Hooks.BEFORE_ADD_LIQUIDITY_FLAG |
+                            Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG |
+                            Hooks.BEFORE_INITIALIZE_FLAG
+                    )
+                )
+            )
+        );
+        deployCodeTo("WETHHook", abi.encode(manager, weth), address(hook));
+    }
+
+    /// @dev Ensure the hook can receive ETH without reverting
+    function test_receive_eth() public {
+        uint256 beforeBalance = address(hook).balance;
+        (bool ok,) = address(hook).call{value: 1 ether}("");
+        assertTrue(ok);
+        assertEq(address(hook).balance, beforeBalance + 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary
- add test ensuring WETHHook can receive ETH
- document test results in a new report

## Testing
- `forge test --match-contract WETHHookReceiveTest`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685e34b0433c832d8a695a75c58f7357