### PR TITLE
Add quoter locker reset test

### DIFF
--- a/reports/report-msgSenderReset-20250627.md
+++ b/reports/report-msgSenderReset-20250627.md
@@ -1,0 +1,17 @@
+# MsgSender Reset After Quote
+
+This report verifies that `V4Quoter` correctly clears the transient sender after a quoting call.
+
+## Summary
+- Added a new test `V4QuoterMsgSenderResetTest` focusing on the `setMsgSender` modifier in `V4Quoter`.
+- The test deploys a minimal `DummyPoolManager` whose `unlock` function reverts with a `QuoteSwap` error. This triggers the quoter's catch block without performing any pool logic.
+- After calling `quoteExactInputSingle`, the test asserts that `msgSender()` returns the zero address, proving the locker was cleared.
+
+## Test Steps
+- Deploy `DummyPoolManager` and `V4Quoter`.
+- Call `quoteExactInputSingle` with trivial parameters; the pool manager revert supplies a quote amount.
+- Immediately read `msgSender()` and expect `address(0)`.
+
+## Findings
+- The test passed, confirming that the `setMsgSender` modifier resets the locker even when quoting completes via a revert-based flow.
+

--- a/test/V4QuoterMsgSenderReset.t.sol
+++ b/test/V4QuoterMsgSenderReset.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {V4Quoter} from "../src/lens/V4Quoter.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {QuoterRevert} from "../src/libraries/QuoterRevert.sol";
+import {IV4Quoter} from "../src/interfaces/IV4Quoter.sol";
+
+contract DummyPoolManager {
+    function unlock(bytes calldata) external pure returns (bytes memory) {
+        QuoterRevert.revertQuote(123);
+    }
+}
+
+contract V4QuoterMsgSenderResetTest is Test {
+    V4Quoter quoter;
+    DummyPoolManager manager;
+
+    function setUp() public {
+        manager = new DummyPoolManager();
+        quoter = new V4Quoter(IPoolManager(address(manager)));
+    }
+
+    function test_msgSender_resets_after_quote() public {
+        IV4Quoter.QuoteExactSingleParams memory params = IV4Quoter.QuoteExactSingleParams({
+            poolKey: PoolKey({
+                currency0: Currency.wrap(address(0)),
+                currency1: Currency.wrap(address(0)),
+                fee: 3000,
+                tickSpacing: 60,
+                hooks: IHooks(address(0))
+            }),
+            zeroForOne: true,
+            exactAmount: 100,
+            hookData: ""
+        });
+
+        quoter.quoteExactInputSingle(params);
+        assertEq(quoter.msgSender(), address(0));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add test for `V4Quoter` ensuring `msgSender` locker resets
- document the new test

## Testing
- `forge test --match-path test/V4QuoterMsgSenderReset.t.sol -vv`
- `forge test`
- `cd lib/v4-core && forge test`

------
https://chatgpt.com/codex/tasks/task_e_685e34b15900832dad48daa3b6617515