### PR TITLE
Add zero-amount tests for DeltaResolver helpers

### DIFF
--- a/test/DeltaResolverMapSettleTake.t.sol
+++ b/test/DeltaResolverMapSettleTake.t.sol
@@ -85,5 +85,15 @@ contract DeltaResolverMapSettleTakeTest is Test {
         vm.expectRevert(abi.encodeWithSelector(DeltaResolver.DeltaNotPositive.selector, tokenCurrency));
         harness.expose_mapTakeAmount(tokenCurrency, ActionConstants.OPEN_DELTA);
     }
+
+    function test_settle_zeroAmount_returnsZero() public view {
+        uint256 amount = harness.expose_mapSettleAmount(tokenCurrency, 0);
+        assertEq(amount, 0);
+    }
+
+    function test_take_zeroAmount_returnsZero() public view {
+        uint256 amount = harness.expose_mapTakeAmount(tokenCurrency, 0);
+        assertEq(amount, 0);
+    }
 }
 

--- a/test/DeltaResolverMapWrapUnwrap.t.sol
+++ b/test/DeltaResolverMapWrapUnwrap.t.sol
@@ -81,5 +81,17 @@ contract DeltaResolverMapWrapUnwrapTest is Test {
         vm.expectRevert(DeltaResolver.InsufficientBalance.selector);
         harness.expose_mapWrapUnwrapAmount(tokenCurrency, 10, tokenCurrency);
     }
+
+    function test_zeroAmount_returnsZero() public {
+        token.mint(address(harness), 5);
+        uint256 amount = harness.expose_mapWrapUnwrapAmount(tokenCurrency, 0, tokenCurrency);
+        assertEq(amount, 0);
+    }
+
+    function test_specificAmount_success() public {
+        token.mint(address(harness), 7);
+        uint256 amount = harness.expose_mapWrapUnwrapAmount(tokenCurrency, 5, tokenCurrency);
+        assertEq(amount, 5);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add new tests covering `_mapWrapUnwrapAmount` with zero/specific amounts
- add tests for `_mapSettleAmount` and `_mapTakeAmount` returning zero

## Testing
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685e34b15900832dad48daa3b6617515