### PR TITLE
Add coverage test for ERC721Permit_v4 and fix import

### DIFF
--- a/reports/report-ERC721PermitCoverage-20250627-0635.md
+++ b/reports/report-ERC721PermitCoverage-20250627-0635.md
@@ -1,0 +1,25 @@
+# ERC721 Permit Coverage Report
+
+## Summary
+This report documents running the full test suite for both the periphery and core packages of Uniswap v4 and adding a new test to cover the previously untested `_isApprovedOrOwner` function.
+
+## Test Methodology
+- Executed `forge test` in the periphery repository and within `lib/v4-core` to run all 666 tests.
+- Generated coverage via `forge coverage` producing an LCOV report.
+- Examined `coverage.xml` and identified that `ERC721Permit_v4._isApprovedOrOwner` had zero line coverage.
+- Created `ERC721PermitHarness` to expose the internal helper and wrote `ERC721PermitIsApprovedOrOwner.t.sol` with targeted cases for owner, approved spender, operator, and unapproved addresses.
+
+## Test Steps
+- Fixed an incorrect import in `StaleSubscriberOnTransfer.t.sol` preventing coverage from running.
+- Added harness and new test contract exercising `_isApprovedOrOwner`.
+- Reran the full test suite ensuring all tests pass.
+
+## Findings
+- All existing tests and the new ones pass successfully as shown at the end of the run:
+```
+Ran 105 test suites in 98.96s (135.17s CPU time): 666 tests passed, 0 failed, 0 skipped (666 total tests)
+```
+- Coverage generation completed without errors and now includes the new test paths.
+
+## Conclusion
+The additional test improves coverage for `ERC721Permit_v4`, ensuring the internal permission check behaves correctly. No functional bugs were uncovered during this effort.

--- a/test/ERC721PermitIsApprovedOrOwner.t.sol
+++ b/test/ERC721PermitIsApprovedOrOwner.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {ERC721PermitHarness} from "./mocks/ERC721PermitHarness.sol";
+
+contract ERC721PermitIsApprovedOrOwnerTest is Test {
+    ERC721PermitHarness token;
+    address alice = address(0x1);
+    address bob = address(0x2);
+    address operator = address(0x3);
+
+    function setUp() public {
+        token = new ERC721PermitHarness("name","SYM");
+    }
+
+    function test_owner_isApprovedOrOwner_true() public {
+        uint256 id = token.mint(alice);
+        vm.prank(alice);
+        assertTrue(token.exposed_isApprovedOrOwner(alice, id));
+    }
+
+    function test_approved_isApprovedOrOwner_true() public {
+        uint256 id = token.mint(alice);
+        vm.prank(alice);
+        token.approve(bob, id);
+        assertTrue(token.exposed_isApprovedOrOwner(bob, id));
+    }
+
+    function test_operator_isApprovedOrOwner_true() public {
+        uint256 id = token.mint(alice);
+        vm.prank(alice);
+        token.setApprovalForAll(operator, true);
+        assertTrue(token.exposed_isApprovedOrOwner(operator, id));
+    }
+
+    function test_unapproved_isApprovedOrOwner_false() public {
+        uint256 id = token.mint(alice);
+        assertFalse(token.exposed_isApprovedOrOwner(bob, id));
+    }
+}

--- a/test/StaleSubscriberOnTransfer.t.sol
+++ b/test/StaleSubscriberOnTransfer.t.sol
@@ -8,7 +8,7 @@ import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
 import {PositionConfig} from "./shared/PositionConfig.sol";
 import {MockTransferSubscriber} from "./mocks/MockTransferSubscriber.sol";
-import {IPositionManager} from "../../src/interfaces/IPositionManager.sol";
+import {IPositionManager} from "../src/interfaces/IPositionManager.sol";
 
 contract StaleSubscriberTest is Test, PosmTestSetup {
     MockTransferSubscriber sub;

--- a/test/mocks/ERC721PermitHarness.sol
+++ b/test/mocks/ERC721PermitHarness.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC721Permit_v4} from "../../src/base/ERC721Permit_v4.sol";
+
+contract ERC721PermitHarness is ERC721Permit_v4 {
+    constructor(string memory name_, string memory symbol_) ERC721Permit_v4(name_, symbol_) {}
+
+    function exposed_isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {
+        return _isApprovedOrOwner(spender, tokenId);
+    }
+
+    function mint(address to) external returns (uint256 tokenId) {
+        tokenId = ++lastTokenId;
+        _mint(to, tokenId);
+    }
+
+    uint256 public lastTokenId;
+
+    function tokenURI(uint256) public pure override returns (string memory) {
+        return "";
+    }
+}


### PR DESCRIPTION
## Summary
- fix incorrect import path in `StaleSubscriberOnTransfer.t.sol`
- add `ERC721PermitHarness` exposing internal `_isApprovedOrOwner`
- add targeted tests for that helper
- include a short coverage report

## Testing
- `forge test -vvv`
- `forge test --match-contract ERC721PermitIsApprovedOrOwnerTest -vvv`


------
https://chatgpt.com/codex/tasks/task_e_685e34b15900832dad48daa3b6617515