### PR TITLE
Add determinism test for HookMiner.computeAddress

### DIFF
--- a/reports/report-HookMinerDeterministic-20250627-0634.md
+++ b/reports/report-HookMinerDeterministic-20250627-0634.md
@@ -1,0 +1,19 @@
+# HookMiner computeAddress determinism
+
+## Summary
+This report adds a regression test ensuring that repeated calls to `HookMiner.computeAddress` with identical inputs produce the same address. The goal is to guard against accidental non-determinism in future changes.
+
+## Methodology
+- Examined existing tests and noticed no direct check that `computeAddress` is deterministic.
+- Created a new test contract `HookMinerDeterministicTest` that calls `computeAddress` twice with the same parameters and compares the results.
+
+## Test Steps
+- Deploy `HookMinerDeterministicTest`.
+- Call `test_computeAddress_deterministic` which computes two addresses using the same deployer, salt, and bytecode.
+- Assert equality of the returned addresses.
+
+## Findings
+- The new test passes, confirming deterministic behaviour.
+
+## Conclusion
+`HookMiner.computeAddress` is deterministic as expected. The added test protects against regressions.

--- a/test/libraries/HookMinerDeterministic.t.sol
+++ b/test/libraries/HookMinerDeterministic.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {HookMiner} from "../../src/utils/HookMiner.sol";
+import {MockBlankHook} from "../mocks/MockBlankHook.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+contract HookMinerDeterministicTest is Test {
+    function test_computeAddress_deterministic() public {
+        address deployer = address(0xabc);
+        bytes memory init = abi.encodePacked(type(MockBlankHook).creationCode, abi.encode(IPoolManager(address(0)), uint256(1), uint16(0)));
+        address a = HookMiner.computeAddress(deployer, 123, init);
+        address b = HookMiner.computeAddress(deployer, 123, init);
+        assertEq(a, b);
+    }
+}


### PR DESCRIPTION
## Summary
- run periphery tests
- add HookMiner determinism unit test
- document the test rationale

## Testing
- `forge test`
- `forge test --match-contract HookMinerDeterministicTest -vv`

------
https://chatgpt.com/codex/tasks/task_e_685e34b15900832dad48daa3b6617515