### PR TITLE
Add AddressStringUtil edge case tests

### DIFF
--- a/reports/report-AddressStringUtilOddLength-20250701.md
+++ b/reports/report-AddressStringUtilOddLength-20250701.md
@@ -1,0 +1,21 @@
+# AddressStringUtil extra length tests - 2025-07-01
+
+## Summary
+Executed full Uniswap v4 periphery and core test suites. All tests succeeded. Coverage remains ~79% periphery and ~83% core. AddressStringUtil library showed about 56% line coverage, so new tests were added for odd-length reverts and partial output.
+
+## Test Methodology
+- Identified low coverage via `forge coverage` output, showing AddressStringUtil around 56% lines.
+- Reviewed existing AddressStringUtil tests; they only checked length zero, >40, and full length case.
+- Added tests to cover odd-length inputs and truncation with hexadecimal letters.
+
+## Test Steps
+- `test_invalid_length_odd` verifies `toAsciiString` reverts when provided an odd length.
+- `test_partial_output_letters` checks eight‑character output from an address containing hex letters to ensure uppercase conversion.
+- Ran `forge test` across the repository to ensure all suites pass.
+
+## Findings
+- New tests passed, confirming proper revert behavior and correct uppercase hex output.
+- Overall coverage numbers did not noticeably change but specific functions are now directly exercised.
+
+## Conclusion
+The Uniswap v4 codebase continues to pass its full suite with high coverage. The added tests strengthen specification of `AddressStringUtil` behavior for edge lengths.

--- a/test/libraries/AddressStringUtilMore.t.sol
+++ b/test/libraries/AddressStringUtilMore.t.sol
@@ -19,9 +19,20 @@ contract AddressStringUtilMoreTest is Test {
         this._call(address(0x1234), 42);
     }
 
+    function test_invalid_length_odd() public {
+        vm.expectRevert(abi.encodeWithSelector(AddressStringUtil.InvalidAddressLength.selector, 5));
+        this._call(address(0x1234), 5);
+    }
+
     function test_full_length_output() public {
         address addr = 0x1234567890123456789012345678901234567890;
         string memory s = AddressStringUtil.toAsciiString(addr, 40);
         assertEq(s, "1234567890123456789012345678901234567890");
+    }
+
+    function test_partial_output_letters() public {
+        address addr = 0xABcdEfaB00000000000000000000000000000000;
+        string memory s = AddressStringUtil.toAsciiString(addr, 8);
+        assertEq(s, "ABCDEFAB");
     }
 }


### PR DESCRIPTION
## Summary
- run full periphery and core suites
- explore coverage output and add new tests for `AddressStringUtil` edge cases

## Testing
- `forge test`
- `forge coverage`


------
https://chatgpt.com/codex/tasks/task_e_685e34b94bb8832d9ba1017d4c328a52