### PR TITLE
Add coverage for large currency color offset

### DIFF
--- a/reports/report-currency-color-offset-large-20250627-0628.md
+++ b/reports/report-currency-color-offset-large-20250627-0628.md
@@ -1,0 +1,11 @@
+# Descriptor currency color offset test
+
+This run targeted the `currencyToColorHex` helper with an offset near the word size boundary.
+
+## Test methodology
+- Constructed a 32 byte value and shifted it by 248 bits (leaving only the highest byte).
+- Called `Descriptor.currencyToColorHex` with this large offset.
+- Expected a three-byte hex string padded with zeros.
+
+## Findings
+- The test passed, confirming the helper correctly handles offsets near 256 bits.

--- a/test/libraries/DescriptorColorUtilsOffsetLarge.t.sol
+++ b/test/libraries/DescriptorColorUtilsOffsetLarge.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {Descriptor} from "../../src/libraries/Descriptor.sol";
+
+contract DescriptorColorUtilsOffsetLargeTest is Test {
+    function test_currencyToColorHex_largeOffset() public pure {
+        uint256 currency = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
+        string memory out = Descriptor.currencyToColorHex(currency, 248);
+        assertEq(out, "000012");
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for `Descriptor.currencyToColorHex` with a very large offset
- document results in a new report

## Testing
- `forge test --match-path test/libraries/DescriptorColorUtilsOffsetLarge.t.sol`

------
https://chatgpt.com/codex/tasks/task_e_685e34bebc6c832dbea39ce541a6864c