### PR TITLE
Add resubscribe after transfer test

### DIFF
--- a/reports/report-resubscribe-transfer-20250627-0616.md
+++ b/reports/report-resubscribe-transfer-20250627-0616.md
@@ -1,0 +1,20 @@
+# Re-subscribe After Transfer
+
+This report documents testing around subscriber state after transferring a position. Existing tests verified that `safeTransferFrom` and `transferFrom` do not notify the current subscriber and clear it. They did not check that a new owner can subscribe the position again.
+
+## Test Methodology
+- **Goal:** Ensure a transferred position may be subscribed again by the new owner.
+- **Preconditions:** A position is minted and subscribed by `alice`. `alice` transfers the token to `bob`.
+- **Assertion:** The subscriber is cleared during transfer and `bob` can successfully subscribe, incrementing `notifySubscribeCount`.
+
+## Test Steps
+1. Mint a position and subscribe it to `MockTransferSubscriber`.
+2. Transfer the position to a new owner.
+3. Verify `notifyTransferCount` remains zero and subscriber address is cleared.
+4. From the new owner, call `subscribe` again and ensure the subscriber is set and `notifySubscribeCount` increments.
+
+## Findings
+- The new `test_resubscribe_after_transfer` passes, confirming that the PositionManager allows re‑subscription after transfer and that notifications behave as expected.
+
+## Conclusion
+No bugs were found. The added test covers a previously unverified success path ensuring transfer semantics leave the position ready for new subscriptions.

--- a/test/position-managers/PositionManager.notifyTransfer.t.sol
+++ b/test/position-managers/PositionManager.notifyTransfer.t.sol
@@ -61,4 +61,27 @@ contract NotifyTransferTest is Test, PosmTestSetup {
         assertEq(sub.notifyTransferCount(), 0);
         assertEq(address(lpm.subscriber(tokenId)), address(0));
     }
+
+    function test_resubscribe_after_transfer() public {
+        uint256 tokenId = lpm.nextTokenId();
+        mint(config, 100e18, alice, ZERO_BYTES);
+
+        vm.startPrank(alice);
+        IERC721(address(lpm)).approve(address(this), tokenId);
+        vm.stopPrank();
+
+        lpm.subscribe(tokenId, address(sub), ZERO_BYTES);
+        assertEq(sub.notifySubscribeCount(), 1);
+
+        IERC721(address(lpm)).transferFrom(alice, bob, tokenId);
+
+        assertEq(sub.notifyTransferCount(), 0);
+        assertEq(address(lpm.subscriber(tokenId)), address(0));
+
+        vm.prank(bob);
+        lpm.subscribe(tokenId, address(sub), ZERO_BYTES);
+
+        assertEq(sub.notifySubscribeCount(), 2);
+        assertEq(address(lpm.subscriber(tokenId)), address(sub));
+    }
 }


### PR DESCRIPTION
## Summary
- add test ensuring new owner can subscribe after transfer
- document the test in a report

## Testing
- `forge test --match-contract NotifyTransferTest -vv`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685e34bebc6c832dbea39ce541a6864c