### PR TITLE
Add SlippageCheck mixed-delta tests

### DIFF
--- a/reports/report-SlippageCheckMixedDelta-20250627.md
+++ b/reports/report-SlippageCheckMixedDelta-20250627.md
@@ -1,0 +1,20 @@
+# SlippageCheck Mixed Delta Tests - 2025-06-27
+
+## Summary
+Expanded tests for the `SlippageCheck` library with scenarios where the balance delta contains both negative and positive amounts. The goal was to ensure negative inputs respect the provided limits while positive components are ignored, as specified in the library comments. Baseline tests all passed and no functional issues were discovered.
+
+## Test Methodology
+- Ran `forge test` to establish a passing baseline of the full suite.
+- Reviewed existing tests and found no coverage for mixed-sign balance deltas in `validateMaxIn`.
+- Created two focused tests exercising a negative/positive delta combination and the exact boundary condition.
+
+## Test Steps
+- **test_validateMaxIn_mixedDelta** – constructs a delta with token0 negative and token1 positive. Calls `validateMaxIn` expecting no revert because the negative side is within limit and positive side is ignored.
+- **test_validateMaxIn_exactBoundary** – uses a negative delta equal to the provided limit to confirm the boundary does not revert.
+
+## Findings
+- All new tests passed alongside the existing suite: `664 tests passed, 0 failed`.
+- The behaviour matched expectations; no bugs were uncovered. The additional checks increase confidence around slippage handling when hooks return mixed deltas.
+
+## Conclusion
+`SlippageCheck` behaves correctly for mixed-sign balance deltas. Existing logic for ignoring positive values and enforcing maximums on negatives works as intended. No further issues identified.

--- a/test/libraries/SlippageCheck.t.sol
+++ b/test/libraries/SlippageCheck.t.sol
@@ -51,6 +51,16 @@ contract SlippageCheckTest is Test {
         harness.callValidateMaxIn(delta, 5, 3);
     }
 
+    function test_validateMaxIn_mixedDelta() public {
+        BalanceDelta delta = toBalanceDelta(-4, 5);
+        harness.callValidateMaxIn(delta, 5, 1);
+    }
+
+    function test_validateMaxIn_exactBoundary() public {
+        BalanceDelta delta = toBalanceDelta(-5, 0);
+        harness.callValidateMaxIn(delta, 5, 1);
+    }
+
     function test_validateMinOut_succeeds() public {
         BalanceDelta delta = toBalanceDelta(5, 6);
         harness.callValidateMinOut(delta, 5, 6);


### PR DESCRIPTION
## Summary
- add tests for mixed sign deltas in `SlippageCheck`
- document results in new report

## Testing
- `forge test`


------
https://chatgpt.com/codex/tasks/task_e_685e34bebc6c832dbea39ce541a6864c