### PR TITLE
Add coverage for Permit2 compact signature helpers

### DIFF
--- a/reports/report-Permit2CompactSig-20250627.md
+++ b/reports/report-Permit2CompactSig-20250627.md
@@ -1,0 +1,22 @@
+# Permit2 compact signature coverage
+
+## Summary
+Added targeted test to exercise `Permit2SignatureHelpers.getCompactPermitSignature` and `_getCompactSignature` which previously lacked coverage.
+
+## Test Methodology
+- Ran full test suite with `forge test` to establish baseline (662 passing).
+- Examined `lcov.info` and found zero coverage for the compact signature helpers.
+- Created `Permit2SignatureHelpersExtra.t.sol` to call `getCompactPermitSignature` and compare to manual output from `_getCompactSignature`.
+
+## Test Steps
+- Build a default permit using `defaultERC20PermitAllowance`.
+- Sign with a fixed private key and domain separator.
+- Invoke `getCompactPermitSignature` to produce a compact signature.
+- Recompute `(r,vs)` using `_getCompactSignature` and assert equality and 64-byte length.
+
+## Findings
+- New test executed successfully and increased coverage counts for both helper functions.
+- No functional issues observed.
+
+## Conclusion
+Targeted test filled the previous gap in `Permit2SignatureHelpers`. Full suite now reports 663 passing tests.

--- a/test/shared/Permit2SignatureHelpersExtra.t.sol
+++ b/test/shared/Permit2SignatureHelpersExtra.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {Permit2SignatureHelpers} from "./Permit2SignatureHelpers.sol";
+import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
+
+contract Permit2SignatureHelpersExtraTest is Test, Permit2SignatureHelpers {
+    function test_getCompactPermitSignature_roundtrip() public {
+        bytes32 domain = bytes32(uint256(0x1234));
+        IAllowanceTransfer.PermitSingle memory permit = defaultERC20PermitAllowance(address(1), 100, 1, 0);
+        uint256 pk = 0x12341234;
+        bytes memory compact = getCompactPermitSignature(permit, pk, domain);
+        (uint8 v, bytes32 r, bytes32 s) = getPermitSignatureRaw(permit, pk, domain);
+        (bytes32 r2, bytes32 vs) = _getCompactSignature(v, r, s);
+        bytes memory expected = bytes.concat(r2, vs);
+        assertEq(compact, expected);
+        assertEq(compact.length, 64);
+    }
+}


### PR DESCRIPTION
## Summary
- add test exercising `getCompactPermitSignature`
- document coverage result

## Testing
- `forge test -vvv test/shared/Permit2SignatureHelpersExtra.t.sol`
- `forge test -vvv`
- `forge coverage --report lcov`

------
https://chatgpt.com/codex/tasks/task_e_685e34bebc6c832dbea39ce541a6864c