### PR TITLE
Add subscriber reset tests

### DIFF
--- a/reports/report-stale-subscriber-transfer-20250627-01.md
+++ b/reports/report-stale-subscriber-transfer-20250627-01.md
@@ -1,0 +1,19 @@
+# Stale subscriber after transfer
+
+## Summary
+This report documents tests addressing subscriber state after a position token is transferred. The goal was to confirm that transferring the token clears any subscriber and causes subsequent unsubscribe calls to revert.
+
+## Test Methodology
+The existing suite lacked checks on the `hasSubscriber` flag after transfers. We added a helper that mints a position, subscribes a mock subscriber and then transfers the token. Two tests cover `safeTransferFrom` and `transferFrom`.
+
+## Test Steps
+- Mint a position and subscribe `MockTransferSubscriber`.
+- Transfer the token from the original owner to a new address using `safeTransferFrom` or `transferFrom` while the pool manager is locked.
+- Assert that `subscriber(tokenId)` is zero and `positionInfo(tokenId).hasSubscriber()` is false.
+- Attempt to unsubscribe as the new owner and expect a `NotSubscribed` revert.
+
+## Findings
+Both tests passed, proving that transfers automatically clear the subscriber and prevent further unsubscribe attempts without a new subscription. No flaws were found.
+
+## Conclusion
+Subscriber state is correctly reset on transfers. These new tests ensure the behavior remains enforced.

--- a/test/StaleSubscriberOnTransfer.t.sol
+++ b/test/StaleSubscriberOnTransfer.t.sol
@@ -8,7 +8,8 @@ import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
 import {PositionConfig} from "./shared/PositionConfig.sol";
 import {MockTransferSubscriber} from "./mocks/MockTransferSubscriber.sol";
-import {IPositionManager} from "../../src/interfaces/IPositionManager.sol";
+import {IPositionManager} from "../src/interfaces/IPositionManager.sol";
+import {INotifier} from "../src/interfaces/INotifier.sol";
 
 contract StaleSubscriberTest is Test, PosmTestSetup {
     MockTransferSubscriber sub;
@@ -30,5 +31,42 @@ contract StaleSubscriberTest is Test, PosmTestSetup {
         config = PositionConfig({poolKey: key, tickLower: -300, tickUpper: 300});
     }
 
- 
+    function _mintAndSubscribe() internal returns (uint256 tokenId) {
+        tokenId = lpm.nextTokenId();
+        mint(config, 100e18, alice, ZERO_BYTES);
+
+        vm.startPrank(alice);
+        IERC721(address(lpm)).approve(address(this), tokenId);
+        vm.stopPrank();
+
+        lpm.subscribe(tokenId, address(sub), ZERO_BYTES);
+    }
+
+    function test_unsubscribe_after_safeTransfer_reverts() public {
+        uint256 tokenId = _mintAndSubscribe();
+
+        vm.prank(alice);
+        IERC721(address(lpm)).safeTransferFrom(alice, bob, tokenId);
+
+        assertEq(address(lpm.subscriber(tokenId)), address(0));
+        assertFalse(lpm.positionInfo(tokenId).hasSubscriber());
+
+        vm.prank(bob);
+        vm.expectRevert(INotifier.NotSubscribed.selector);
+        lpm.unsubscribe(tokenId);
+    }
+
+    function test_unsubscribe_after_transferFrom_reverts() public {
+        uint256 tokenId = _mintAndSubscribe();
+
+        vm.prank(alice);
+        IERC721(address(lpm)).transferFrom(alice, bob, tokenId);
+
+        assertEq(address(lpm.subscriber(tokenId)), address(0));
+        assertFalse(lpm.positionInfo(tokenId).hasSubscriber());
+
+        vm.prank(bob);
+        vm.expectRevert(INotifier.NotSubscribed.selector);
+        lpm.unsubscribe(tokenId);
+    }
 }


### PR DESCRIPTION
## Summary
- add tests for stale subscriber state after token transfers
- document test results in new report

## Testing
- `forge test -q`
- `forge test --match-path test/StaleSubscriberOnTransfer.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_685e34c3ae8c832dbee41ba7cf5d28ad