### PR TITLE
Improve coverage for address and svg utilities

### DIFF
--- a/reports/report-address-string-svg-substring-20250701.md
+++ b/reports/report-address-string-svg-substring-20250701.md
@@ -1,0 +1,18 @@
+# Address and SVG Utility Coverage Extension
+
+This update adds targeted unit tests to better cover edge cases in `AddressStringUtil` and `SVG` utilities.
+
+## Test Methodology
+- **AddressStringUtil**: existing coverage missed scenarios with uppercase hex characters when requesting a substring shorter than the full address. The new test calls `toAsciiString` with a mixed-case address and length 6 to ensure letters `A-F` are handled correctly.
+- **SVG.substring**: prior tests only covered error conditions. A new check verifies that requesting a zero-length slice returns an empty string.
+
+## Test Steps
+- Extend `AddressStringUtilMore.t.sol` with `test_partial_length_with_letters` that asserts the first three bytes of a mixed-case address are converted to uppercase correctly.
+- Extend `SVGExtended.t.sol` with `test_substring_empty_result` verifying a zero-length substring returns `""`.
+
+## Findings
+- Both new tests pass, confirming the utilities behave as expected with these edge cases. No functional bugs were uncovered.
+- Overall line coverage after the additions is approximately **79%**, as reported by `forge coverage`.
+
+## Conclusion
+The added tests increase confidence in string and substring handling within helper libraries, addressing low coverage areas without revealing further issues. Future efforts may explore deeper testing of complex SVG generation paths for improved coverage.

--- a/test/libraries/AddressStringUtilMore.t.sol
+++ b/test/libraries/AddressStringUtilMore.t.sol
@@ -24,4 +24,10 @@ contract AddressStringUtilMoreTest is Test {
         string memory s = AddressStringUtil.toAsciiString(addr, 40);
         assertEq(s, "1234567890123456789012345678901234567890");
     }
+
+    function test_partial_length_with_letters() public {
+        address addr = 0xabCdEF1234567890aBcdefAbCDEFabCdEfAbCdeF;
+        string memory s = AddressStringUtil.toAsciiString(addr, 6);
+        assertEq(s, "ABCDEF");
+    }
 }

--- a/test/libraries/SVGExtended.t.sol
+++ b/test/libraries/SVGExtended.t.sol
@@ -53,4 +53,9 @@ contract SVGExtendedTest is Test {
         vm.expectRevert(stdError.arithmeticError);
         harness.substringExternal("hello", 6, 3);
     }
+
+    function test_substring_empty_result() public {
+        string memory result = harness.substringExternal("hello", 2, 2);
+        assertEq(result, "");
+    }
 }


### PR DESCRIPTION
## Summary
- add uppercase path coverage to AddressStringUtil
- test zero-length substring handling in SVG library
- document new tests and coverage numbers

## Testing
- `forge test`
- `forge coverage --report summary`

------
https://chatgpt.com/codex/tasks/task_e_685e34c3ae8c832dbee41ba7cf5d28ad