### PR TITLE
Add test for empty BaseActionsRouter plan

### DIFF
--- a/reports/report-base-actions-zero-20250627.md
+++ b/reports/report-base-actions-zero-20250627.md
@@ -1,0 +1,14 @@
+# BaseActionsRouter handles empty actions list
+
+This short report adds a test ensuring that executing a plan with no actions on `BaseActionsRouter` is a no-op. The existing suite covered multiple actions but never the zero-length case.
+
+## Test Methodology
+- Deployed `MockBaseActionsRouter` via the `Deployers` utility.
+- Created an empty `Plan` using the helper library and executed it.
+- Asserted that counters such as `swapCount` and `mintCount` remain zero after execution.
+
+## Findings
+- The new test `test_executeActions_zeroActions_noop` passed, confirming the router gracefully handles empty action lists without reverting.
+
+## Conclusion
+No issues were uncovered by this additional test. It fills a small coverage gap around handling of empty inputs in `BaseActionsRouter`.

--- a/test/BaseActionsRouterZero.t.sol
+++ b/test/BaseActionsRouterZero.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {MockBaseActionsRouter} from "./mocks/MockBaseActionsRouter.sol";
+import {Planner} from "./shared/Planner.sol";
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+
+contract BaseActionsRouterZeroTest is Test, Deployers {
+    MockBaseActionsRouter router;
+
+    function setUp() public {
+        deployFreshManager();
+        router = new MockBaseActionsRouter(manager);
+    }
+
+    function test_executeActions_zeroActions_noop() public {
+        bytes memory data = Planner.init().encode();
+        router.executeActions(data);
+        assertEq(router.swapCount(), 0);
+        assertEq(router.mintCount(), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add BaseActionsRouterZeroTest covering case with no actions
- document findings

## Testing
- `forge test -v test/BaseActionsRouterZero.t.sol`
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685e34d6a8b4832d857195f6fc13a3f8