### PR TITLE
Add base64 empty input test

### DIFF
--- a/reports/report-base64-empty-decode-20250627.md
+++ b/reports/report-base64-empty-decode-20250627.md
@@ -1,0 +1,15 @@
+# Base64 Empty Decode Test
+
+## Summary
+Added a unit test for decoding an empty base64 string to ensure the helper returns an empty byte array instead of reverting.
+
+## Methodology
+- Searched coverage results and noted `Base64.decode` lacked a case for zero-length input.
+- Extended `Base64Test` with `test_decode_empty_returnsEmptyBytes` which calls the decode library via `DecodeCaller`.
+
+## Findings
+- The new test confirms decoding an empty string yields an empty byte array.
+- No regressions were observed in the suite.
+
+## Conclusion
+Handling of empty inputs behaves as expected. This improves confidence in the utility library's edge cases.

--- a/test/Base64.t.sol
+++ b/test/Base64.t.sol
@@ -12,4 +12,10 @@ contract Base64Test is Test {
         vm.expectRevert(bytes("invalid base64 decoder input"));
         caller.callDecode(bad);
     }
+
+    function test_decode_empty_returnsEmptyBytes() public {
+        DecodeCaller caller = new DecodeCaller();
+        bytes memory result = caller.callDecode("");
+        assertEq(result.length, 0);
+    }
 }


### PR DESCRIPTION
## Summary
- test Base64.decode on empty string
- document reasoning in new report

## Testing
- `forge test -vvv --match-contract Base64Test`

------
https://chatgpt.com/codex/tasks/task_e_685e34d6a8b4832d857195f6fc13a3f8