### PR TITLE
Increase test coverage for approval and position info

### DIFF
--- a/reports/report-coverage-improvements-20250627.md
+++ b/reports/report-coverage-improvements-20250627.md
@@ -1,0 +1,20 @@
+# Coverage Improvements 2025-06-27
+
+## Summary
+Added tests for internal approval checks in `ERC721Permit_v4` and the parameterized `StateView.getPositionInfo` path. These tests increase coverage for previously untouched functions.
+
+## Methodology
+- Identified functions with zero execution counts in `lcov.info`, specifically `ERC721Permit_v4._isApprovedOrOwner` and `StateView.getPositionInfo` with explicit parameters.
+- Created a harness contract exposing `_isApprovedOrOwner`.
+- Wrote unit tests exercising owner, approved, and unauthorized cases.
+- Added a new test invoking `StateView.getPositionInfo` with owner and tick parameters and verifying liquidity and fee growth values.
+
+## Test Steps
+- `ERC721Permit.isApproved.t.sol` validates `_isApprovedOrOwner` for owner, approved spender, and unapproved spender.
+- `StateViewTest.t.sol` `test_getPositionInfo_fullParams` adds liquidity, performs a swap, updates fees, then queries position info using all parameters.
+
+## Findings
+- All new tests pass, confirming correct behavior for the previously uncovered code paths.
+
+## Conclusion
+The suite now covers additional approval logic and position query pathways. No issues were found.

--- a/test/StateViewTest.t.sol
+++ b/test/StateViewTest.t.sol
@@ -287,6 +287,25 @@ contract StateViewTest is Test, Deployers, Fuzzers {
         assertEq(feeGrowthInside1X128, 0);
     }
 
+    function test_getPositionInfo_fullParams() public {
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES);
+        uint256 swapAmount = 10 ether;
+        swap(key, true, -int256(swapAmount), ZERO_BYTES);
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 0, 0), ZERO_BYTES);
+
+        (uint128 liquidity, uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) = state.getPositionInfo(
+            poolId,
+            address(modifyLiquidityRouter),
+            -60,
+            60,
+            bytes32(0)
+        );
+
+        assertEq(liquidity, 10_000 ether);
+        assertNotEq(feeGrowthInside0X128, 0);
+        assertEq(feeGrowthInside1X128, 0);
+    }
+
     function test_fuzz_getPositionInfo(ModifyLiquidityParams memory params, uint256 swapAmount, bool zeroForOne)
         public
     {

--- a/test/erc721Permit/ERC721Permit.isApproved.t.sol
+++ b/test/erc721Permit/ERC721Permit.isApproved.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {MockERC721PermitHarness} from "../harness/MockERC721PermitHarness.sol";
+
+contract ERC721PermitIsApprovedTest is Test {
+    MockERC721PermitHarness token;
+    address bob = address(0xB0B);
+
+    function setUp() public {
+        token = new MockERC721PermitHarness("Mock", "MOCK");
+    }
+
+    function test_isApprovedOrOwner_owner() public {
+        uint256 tokenId = token.mint();
+        assertTrue(token.isApprovedOrOwner(address(this), tokenId));
+    }
+
+    function test_isApprovedOrOwner_approved() public {
+        uint256 tokenId = token.mint();
+        token.approve(bob, tokenId);
+        assertTrue(token.isApprovedOrOwner(bob, tokenId));
+    }
+
+    function test_isApprovedOrOwner_unapproved() public {
+        uint256 tokenId = token.mint();
+        assertFalse(token.isApprovedOrOwner(bob, tokenId));
+    }
+}

--- a/test/harness/MockERC721PermitHarness.sol
+++ b/test/harness/MockERC721PermitHarness.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.8.20;
+
+import {ERC721Permit_v4} from "../../src/base/ERC721Permit_v4.sol";
+
+contract MockERC721PermitHarness is ERC721Permit_v4 {
+    uint256 public lastTokenId;
+
+    constructor(string memory name, string memory symbol) ERC721Permit_v4(name, symbol) {}
+
+    function mint() external returns (uint256 tokenId) {
+        tokenId = ++lastTokenId;
+        _mint(msg.sender, tokenId);
+    }
+
+    function tokenURI(uint256) public pure override returns (string memory) {
+        return "mock";
+    }
+
+    function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {
+        return _isApprovedOrOwner(spender, tokenId);
+    }
+}


### PR DESCRIPTION
## Summary
- add harness for `ERC721Permit_v4` to expose `_isApprovedOrOwner`
- test approval status via new harness
- cover `StateView.getPositionInfo` variant with full parameters
- document coverage improvements

## Testing
- `forge test --match-test isApprovedOrOwner`
- `forge test --match-test test_getPositionInfo_fullParams`
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685e34dda938832d9d310f822a49cd26