### PR TITLE
Add locker persistence test

### DIFF
--- a/reports/report-locker-transient-20250627-01.md
+++ b/reports/report-locker-transient-20250627-01.md
@@ -1,0 +1,20 @@
+# Locker Transient Storage Behavior
+
+## Summary
+The goal was to verify how `Locker`'s transient storage behaves across multiple external calls within the same transaction. All existing tests only examined operations within a single call. The new test demonstrates that the locker value persists across calls in the same transaction.
+
+## Test Methodology
+- Focused on `Locker` library, specifically state persistence between calls.
+- Assumed transient storage should remain set until the transaction ends.
+
+## Test Steps
+- Added `test_value_persists_across_calls_in_tx` in `LockerTest`.
+- Call `setLocker` once, then call `getLocker` in a second external call.
+- Assert that `getLocker` returns the previously set address.
+
+## Findings
+- The new test passes, confirming `Locker.set` values persist across calls within the same transaction.
+- No issues were discovered with the library’s logic.
+
+## Conclusion
+The additional coverage verifies expected transient storage semantics for `Locker`. No flaws were uncovered.

--- a/test/libraries/Locker.t.sol
+++ b/test/libraries/Locker.t.sol
@@ -41,4 +41,9 @@ contract LockerTest is Test {
     function test_get_without_set_returns_zero() public {
         assertEq(harness.getLocker(), address(0));
     }
+
+    function test_value_persists_across_calls_in_tx() public {
+        harness.setLocker(address(0xBEEF));
+        assertEq(harness.getLocker(), address(0xBEEF));
+    }
 }


### PR DESCRIPTION
## Summary
- add a regression test covering Locker's behavior across multiple external calls
- document test results in a new report

## Testing
- `forge test --match-path test/libraries/Locker.t.sol -vv`
- `forge test -q`

------
https://chatgpt.com/codex/tasks/task_e_685e34e0937c832db82aaece471bedc7