### PR TITLE
Add SafeCurrencyMetadata edge tests

### DIFF
--- a/reports/report-SafeCurrencyMetadataEdge-20250627.md
+++ b/reports/report-SafeCurrencyMetadataEdge-20250627.md
@@ -1,0 +1,20 @@
+# SafeCurrencyMetadata edge cases 20250627
+
+## Summary
+Added tests for SafeCurrencyMetadata to cover cases where `symbol()` returns an empty string without reverting and when `decimals()` returns malformed short data. All tests pass and coverage improves for these paths.
+
+## Test Methodology
+- **EmptySymbolToken**: Contract that returns an empty string from `symbol()` without reverting.
+- **ShortDecimalsToken**: Contract that returns 31 bytes of data from `decimals()` via inline assembly.
+- Added two tests in `SafeCurrencyMetadataEdgeTest` verifying fallback behaviors.
+
+## Test Steps
+- Call `currencySymbol` on `EmptySymbolToken` expecting fallback to address-based symbol.
+- Call `currencyDecimals` on `ShortDecimalsToken` expecting a return of zero due to malformed data.
+
+## Findings
+- `currencySymbol` correctly falls back when symbol is empty.
+- `currencyDecimals` returns zero for malformed short data as intended.
+
+## Conclusion
+The added tests strengthen coverage of SafeCurrencyMetadata for unusual token implementations without revealing flaws. The library handles these edge cases gracefully.

--- a/test/libraries/SafeCurrencyMetadataAdditional.t.sol
+++ b/test/libraries/SafeCurrencyMetadataAdditional.t.sol
@@ -3,26 +3,54 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 import {SafeCurrencyMetadata} from "../../src/libraries/SafeCurrencyMetadata.sol";
+import {AddressStringUtil} from "../../src/libraries/AddressStringUtil.sol";
 
 contract Bytes32SymbolToken {
     bytes32 private symbolValue;
-    constructor(bytes32 s) { symbolValue = s; }
-    function symbol() external view returns (bytes32) { return symbolValue; }
-    function decimals() external pure returns (uint256) { return 18; }
+
+    constructor(bytes32 s) {
+        symbolValue = s;
+    }
+
+    function symbol() external view returns (bytes32) {
+        return symbolValue;
+    }
+
+    function decimals() external pure returns (uint256) {
+        return 18;
+    }
 }
 
 contract StringSymbolToken {
     string private symbolValue;
-    constructor(string memory s) { symbolValue = s; }
-    function symbol() external view returns (string memory) { return symbolValue; }
-    function decimals() external pure returns (uint256) { return 18; }
+
+    constructor(string memory s) {
+        symbolValue = s;
+    }
+
+    function symbol() external view returns (string memory) {
+        return symbolValue;
+    }
+
+    function decimals() external pure returns (uint256) {
+        return 18;
+    }
 }
 
 contract StringDecimalsToken {
     string private decimalsValue;
-    constructor(string memory d) { decimalsValue = d; }
-    function symbol() external pure returns (string memory) { return "T"; }
-    function decimals() external view returns (string memory) { return decimalsValue; }
+
+    constructor(string memory d) {
+        decimalsValue = d;
+    }
+
+    function symbol() external pure returns (string memory) {
+        return "T";
+    }
+
+    function decimals() external view returns (string memory) {
+        return decimalsValue;
+    }
 }
 
 contract SafeCurrencyMetadataAdditionalTest is Test {
@@ -38,6 +66,42 @@ contract SafeCurrencyMetadataAdditionalTest is Test {
 
     function test_currencyDecimals_stringReturn() public {
         StringDecimalsToken t = new StringDecimalsToken("18");
+        assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 0);
+    }
+}
+
+contract EmptySymbolToken {
+    function symbol() external pure returns (string memory) {
+        return "";
+    }
+
+    function decimals() external pure returns (uint256) {
+        return 18;
+    }
+}
+
+contract ShortDecimalsToken {
+    function symbol() external pure returns (string memory) {
+        return "S";
+    }
+
+    function decimals() external pure returns (uint256 result) {
+        assembly {
+            mstore(0x0, 17)
+            return(0x0, 31)
+        }
+    }
+}
+
+contract SafeCurrencyMetadataEdgeTest is Test {
+    function test_currencySymbol_emptyString() public {
+        EmptySymbolToken t = new EmptySymbolToken();
+        string memory expected = AddressStringUtil.toAsciiString(address(t), 6);
+        assertEq(SafeCurrencyMetadata.currencySymbol(address(t), "N"), expected);
+    }
+
+    function test_currencyDecimals_shortReturn() public {
+        ShortDecimalsToken t = new ShortDecimalsToken();
         assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 0);
     }
 }


### PR DESCRIPTION
## Summary
- extend SafeCurrencyMetadataAdditional tests
- add EmptySymbolToken and ShortDecimalsToken edge contracts
- cover empty symbol and short decimals cases
- document results in new report

## Testing
- `forge test -vvv`


------
https://chatgpt.com/codex/tasks/task_e_685e34e55a54832d867be4835bc3dd89