### PR TITLE
Add Base64 decode padding tests

### DIFF
--- a/reports/report-base64-padding-20250630-01.md
+++ b/reports/report-base64-padding-20250630-01.md
@@ -1,0 +1,21 @@
+# Base64 padding edge cases
+
+## Summary
+This report documents additional tests for the internal `Base64` decoder covering empty inputs and strings that require one or two `=` padding characters. The existing suite lacked explicit checks for these paths.
+
+## Test Methodology
+- Attempted to run the entire suite using `forge test`. The run intermittently fails in `HookMinerTest` due to the probabilistic nature of `HookMiner.find` failing to locate a salt in 160k iterations. This reveals a potential fragility in the library but does not relate to the new tests.
+- Reviewed previous coverage reports which indicated the `Base64` library had minimal positive decoding tests.
+- Wrote `Base64EdgeTest` exercising decoding of empty strings and inputs with single and double padding.
+
+## Test Steps
+- `test_decode_empty` ensures decoding `""` returns an empty byte array.
+- `test_decode_single_padding` decodes `"TWE="` yielding `"Ma"`.
+- `test_decode_double_padding` decodes `"TQ=="` yielding `"M"`.
+
+## Findings
+- All new tests pass and confirm the decoder handles these edge cases.
+- Running the full test suite occasionally triggers `HookMiner` fuzz failures, suggesting the search loop is not guaranteed to succeed for all flags.
+
+## Conclusion
+The added tests improve coverage of base64 decoding behavior without altering contract logic. Future work may investigate the nondeterministic failure observed in `HookMiner.find` when fuzzing.

--- a/test/Base64Edge.t.sol
+++ b/test/Base64Edge.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {DecodeCaller} from "./DecodeCaller.sol";
+
+contract Base64EdgeTest is Test {
+    function test_decode_empty() public {
+        DecodeCaller caller = new DecodeCaller();
+        bytes memory out = caller.callDecode("");
+        assertEq(out.length, 0);
+    }
+
+    function test_decode_single_padding() public {
+        DecodeCaller caller = new DecodeCaller();
+        bytes memory out = caller.callDecode("TWE=");
+        assertEq(out, bytes("Ma"));
+    }
+
+    function test_decode_double_padding() public {
+        DecodeCaller caller = new DecodeCaller();
+        bytes memory out = caller.callDecode("TQ==");
+        assertEq(out, bytes("M"));
+    }
+}


### PR DESCRIPTION
## Summary
- cover Base64 decoder behavior for empty input and padded strings
- document new tests and fuzzing observation about `HookMiner.find`

## Testing
- `forge test --match-path test/Base64Edge.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_685e34e0937c832db82aaece471bedc7