### PR TITLE
Update Quoter gas snapshot

### DIFF
--- a/snapshots/QuoterTest.json
+++ b/snapshots/QuoterTest.json
@@ -1,15 +1,15 @@
 {
-  "Quoter_exactInputSingle_oneForZero_multiplePositions": "146134",
-  "Quoter_exactInputSingle_zeroForOne_multiplePositions": "152349",
-  "Quoter_exactOutputSingle_oneForZero": "79477",
-  "Quoter_exactOutputSingle_zeroForOne": "84722",
-  "Quoter_quoteExactInput_oneHop_1TickLoaded": "122938",
-  "Quoter_quoteExactInput_oneHop_initializedAfter": "147573",
-  "Quoter_quoteExactInput_oneHop_startingInitialized": "80848",
-  "Quoter_quoteExactInput_twoHops": "205152",
-  "Quoter_quoteExactOutput_oneHop_1TickLoaded": "122434",
-  "Quoter_quoteExactOutput_oneHop_2TicksLoaded": "153089",
-  "Quoter_quoteExactOutput_oneHop_initializedAfter": "122461",
-  "Quoter_quoteExactOutput_oneHop_startingInitialized": "98755",
-  "Quoter_quoteExactOutput_twoHops": "204880"
+  "Quoter_exactInputSingle_oneForZero_multiplePositions": "124514",
+  "Quoter_exactInputSingle_zeroForOne_multiplePositions": "130728",
+  "Quoter_exactOutputSingle_oneForZero": "58110",
+  "Quoter_exactOutputSingle_zeroForOne": "63345",
+  "Quoter_quoteExactInput_oneHop_1TickLoaded": "101485",
+  "Quoter_quoteExactInput_oneHop_initializedAfter": "126099",
+  "Quoter_quoteExactInput_oneHop_startingInitialized": "48886",
+  "Quoter_quoteExactInput_twoHops": "183488",
+  "Quoter_quoteExactOutput_oneHop_1TickLoaded": "101118",
+  "Quoter_quoteExactOutput_oneHop_2TicksLoaded": "131773",
+  "Quoter_quoteExactOutput_oneHop_initializedAfter": "101145",
+  "Quoter_quoteExactOutput_oneHop_startingInitialized": "56151",
+  "Quoter_quoteExactOutput_twoHops": "183471"
 }


### PR DESCRIPTION
## Summary
- update Quoter gas snapshot numbers so `forge snapshot --check` passes

## Testing
- `forge test --match-contract QuoterTest -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685f23966c9c832dbcba3c1271ae5890