### PR TITLE
Add boundary tests for currencyDecimals

### DIFF
--- a/reports/report-SafeCurrencyDecimalsEdge-20250627.md
+++ b/reports/report-SafeCurrencyDecimalsEdge-20250627.md
@@ -1,0 +1,20 @@
+# SafeCurrencyMetadata Decimal Boundary Tests
+
+This report documents additional tests for `SafeCurrencyMetadata` covering decimal boundary conditions.
+
+## Test Methodology
+
+The library's `currencyDecimals` function returns the decimals of a token or zero if the returned value is invalid. Existing tests covered standard and overflow cases but did not verify the boundaries at `uint8` limits.
+
+## Test Steps
+
+- **test_currencyDecimals_maxUint8**: Deploy a `MockToken` returning `255` for `decimals()`. Expect `currencyDecimals` to return `255`.
+- **test_currencyDecimals_boundary256**: Deploy a `MockToken` returning `256` for `decimals()`. Expect a result of `0` as the value exceeds `uint8`.
+
+## Findings
+
+Both tests passed, confirming the library correctly handles edge values at the boundary of the `uint8` range.
+
+## Conclusion
+
+The new tests strengthen coverage around `currencyDecimals` by verifying behavior for the maximum valid value and the smallest overflow case.

--- a/test/libraries/SafeCurrencyMetadata.t.sol
+++ b/test/libraries/SafeCurrencyMetadata.t.sol
@@ -61,6 +61,16 @@ contract SafeCurrencyMetadataExtraTest is Test {
         assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 0);
     }
 
+    function test_currencyDecimals_maxUint8() public {
+        MockToken t = new MockToken("ABC", 255, false, false);
+        assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 255);
+    }
+
+    function test_currencyDecimals_boundary256() public {
+        MockToken t = new MockToken("ABC", 256, false, false);
+        assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 0);
+    }
+
     function test_currencyDecimals_revert() public {
         MockToken t = new MockToken("ABC", 18, false, true);
         assertEq(SafeCurrencyMetadata.currencyDecimals(address(t)), 0);


### PR DESCRIPTION
## Summary
- expand SafeCurrencyMetadata decimals tests for boundary values
- document new checks in a report

## Testing
- `forge test`

------
https://chatgpt.com/codex/tasks/task_e_685e36e04e48832d9fe7dc1a6a87068a