### PR TITLE
Add UniswapV4DeployerCompetition initialization test

### DIFF
--- a/reports/report-ExclusiveDeployDeadline-20250627.md
+++ b/reports/report-ExclusiveDeployDeadline-20250627.md
@@ -1,0 +1,20 @@
+# UniswapV4DeployerCompetition initialization test
+
+## Summary
+Added a focused unit test verifying that `exclusiveDeployDeadline` is derived correctly from the constructor arguments of `UniswapV4DeployerCompetition`.
+
+## Methodology
+- Ran the full Forge suite to establish a baseline (663 passing tests).
+- Reviewed coverage reports and noticed that the initial value of `exclusiveDeployDeadline` had no direct assertion.
+- Created `UniswapV4DeployerCompetitionInitTest` with a single assertion of the deadline calculation and deployer address.
+
+## Test Steps
+- Deploy `UniswapV4DeployerCompetition` with a known competition deadline and exclusive period.
+- Assert that `exclusiveDeployDeadline()` equals `competitionDeadline + exclusiveDeployLength`.
+- Assert that the deployer address is stored correctly.
+
+## Findings
+- The new test passed and the entire suite remained green, confirming the constructor logic works as expected.
+
+## Conclusion
+Constructor parameters for `UniswapV4DeployerCompetition` are handled correctly. This small gap in initialization checks is now covered.

--- a/test/UniswapV4DeployerCompetitionInit.t.sol
+++ b/test/UniswapV4DeployerCompetitionInit.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {UniswapV4DeployerCompetition} from "../src/UniswapV4DeployerCompetition.sol";
+import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
+
+contract UniswapV4DeployerCompetitionInitTest is Test {
+    UniswapV4DeployerCompetition competition;
+    uint256 competitionDeadline;
+    uint256 exclusiveDeployLength = 2 days;
+    address deployer = address(0x1234);
+    address owner = address(0x5678);
+
+    function setUp() public {
+        competitionDeadline = block.timestamp + 10 days;
+        bytes32 initCodeHash = keccak256(abi.encodePacked(type(PoolManager).creationCode, uint256(uint160(owner))));
+        competition = new UniswapV4DeployerCompetition(initCodeHash, competitionDeadline, deployer, exclusiveDeployLength);
+    }
+
+    function test_exclusiveDeployDeadline_calculation() public {
+        assertEq(competition.exclusiveDeployDeadline(), competitionDeadline + exclusiveDeployLength);
+        assertEq(competition.deployer(), deployer);
+    }
+}


### PR DESCRIPTION
## Summary
- run the full test suite
- add a unit test verifying the constructor deadline math
- document the test in a new report

## Testing
- `forge test`


------
https://chatgpt.com/codex/tasks/task_e_685e36e04e48832d9fe7dc1a6a87068a