### PR TITLE
Add zero-hop swap tests

### DIFF
--- a/reports/report-zero-hop-swap-20250627.md
+++ b/reports/report-zero-hop-swap-20250627.md
@@ -1,0 +1,20 @@
+# Zero Hop Swap Tests - 20250627
+
+## Summary
+This report covers new test cases targeting zero-hop swap scenarios in `V4Router`. The goal was to ensure edge cases where the swap path is empty behave as expected.
+
+## Test Methodology
+- **swapExactIn_zeroHop_reverts**: verifies that providing no path for an exact-input swap causes a `V4TooLittleReceived` revert when a minimum amount is specified.
+- **swapExactOut_zeroHop_noop**: checks that a zero-hop exact-output swap performs no action and leaves token balances unchanged.
+
+## Test Steps
+- Constructed empty `tokenPath` arrays for each new test.
+- Used existing helpers to create `ExactInputParams` and `ExactOutputParams` with these paths.
+- Executed actions via the router and captured balance changes.
+
+## Findings
+- **swapExactIn_zeroHop_reverts**: reverted with `V4TooLittleReceived` as expected, confirming safety against nonsensical swaps.
+- **swapExactOut_zeroHop_noop**: executed successfully without altering balances, showing the router treats such calls as no-ops.
+
+## Conclusion
+Zero-hop swap cases now have explicit coverage. The router correctly reverts when a minimum output is required and otherwise results in a no-op. No flaws were discovered.

--- a/test/router/V4Router.t.sol
+++ b/test/router/V4Router.t.sol
@@ -270,6 +270,35 @@ contract V4RouterTest is RoutingTestHelpers {
         assertEq(outputBalanceAfter - outputBalanceBefore, expectedAmountOut);
     }
 
+    function test_swapExactIn_zeroHop_reverts() public {
+        uint256 amountIn = 1 ether;
+
+        tokenPath.push(currency0);
+        IV4Router.ExactInputParams memory params = _getExactInputParams(tokenPath, amountIn);
+        params.amountOutMinimum = 1;
+
+        plan = plan.add(Actions.SWAP_EXACT_IN, abi.encode(params));
+        bytes memory data = plan.finalizeSwap(currency0, currency0, ActionConstants.MSG_SENDER);
+
+        vm.expectRevert(abi.encodeWithSelector(IV4Router.V4TooLittleReceived.selector, 1, 0));
+        router.executeActions(data);
+    }
+
+    function test_swapExactOut_zeroHop_noop() public {
+        uint256 amountOut = 1 ether;
+
+        tokenPath.push(currency0);
+        IV4Router.ExactOutputParams memory params = _getExactOutputParams(tokenPath, amountOut);
+
+        plan = plan.add(Actions.SWAP_EXACT_OUT, abi.encode(params));
+
+        (uint256 inputBalanceBefore, uint256 outputBalanceBefore, uint256 inputBalanceAfter, uint256 outputBalanceAfter)
+        = _finalizeAndExecuteSwap(currency0, currency0, 0);
+
+        assertEq(inputBalanceBefore, inputBalanceAfter);
+        assertEq(outputBalanceBefore, outputBalanceAfter);
+    }
+
     function test_swap_settleRouterBalance_swapOpenDelta() public {
         uint256 amountIn = 1 ether;
         uint256 expectedAmountOut = 992054607780215625;


### PR DESCRIPTION
## Summary
- add tests for zero-hop exact input/output in router
- document in new report

## Testing
- `forge test --match-path test/router/V4Router.t.sol -vvv`
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_685f29ed6f7c832db2c6f12ad27d62dc