### PR TITLE
Add tests for documented vulnerabilities

### DIFF
--- a/test/vulnerabilities/NativeWrapperForceSend.t.sol
+++ b/test/vulnerabilities/NativeWrapperForceSend.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {NativeWrapper} from "../../src/base/NativeWrapper.sol";
+import {ImmutableState} from "../../src/base/ImmutableState.sol";
+import {IWETH9} from "../../src/interfaces/external/IWETH9.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+
+contract ForceSend {
+    constructor() payable {}
+
+    function attack(address target) external {
+        selfdestruct(payable(target));
+    }
+}
+
+contract MockPoolManager {}
+
+contract NativeWrapperHarness is NativeWrapper {
+    constructor(IWETH9 _weth9, IPoolManager _pm) ImmutableState(_pm) NativeWrapper(_weth9) {}
+}
+
+contract NativeWrapperForceSendTest is Test {
+    NativeWrapperHarness wrapper;
+    WETH weth;
+    MockPoolManager pm;
+
+    function setUp() public {
+        weth = new WETH();
+        pm = new MockPoolManager();
+        wrapper = new NativeWrapperHarness(IWETH9(address(weth)), IPoolManager(address(pm)));
+    }
+
+    function test_force_send_eth_via_selfdestruct() public {
+        ForceSend fs = new ForceSend{value: 1 ether}();
+        fs.attack(address(wrapper));
+        assertEq(address(wrapper).balance, 1 ether);
+    }
+}

--- a/test/vulnerabilities/PoolReinit.t.sol
+++ b/test/vulnerabilities/PoolReinit.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+import {PoolInitializer_v4} from "../../src/base/PoolInitializer_v4.sol";
+import {ImmutableState} from "../../src/base/ImmutableState.sol";
+
+contract MockPoolManagerReinit {
+    bool public initialized;
+    uint160 public lastPrice;
+
+    function initialize(PoolKey memory, uint160 sqrtPriceX96) external returns (int24) {
+        if (initialized) revert("already init");
+        initialized = true;
+        lastPrice = sqrtPriceX96;
+        return 5;
+    }
+}
+
+contract PoolInitializerHarness is PoolInitializer_v4 {
+    constructor(IPoolManager _pm) ImmutableState(_pm) {}
+}
+
+contract PoolReinitTest is Test {
+    PoolInitializerHarness harness;
+    MockPoolManagerReinit manager;
+    PoolKey key;
+
+    function setUp() public {
+        manager = new MockPoolManagerReinit();
+        harness = new PoolInitializerHarness(IPoolManager(address(manager)));
+        key = PoolKey({
+            currency0: Currency.wrap(address(1)),
+            currency1: Currency.wrap(address(2)),
+            fee: 0,
+            tickSpacing: 1,
+            hooks: IHooks(address(0))
+        });
+    }
+
+    function test_reinitialize_returns_sentinel() public {
+        int24 first = harness.initializePool(key, 123);
+        assertEq(first, 5);
+
+        int24 second = harness.initializePool(key, 456);
+        assertEq(second, type(int24).max);
+    }
+}

--- a/test/vulnerabilities/WstETHHookRounding.t.sol
+++ b/test/vulnerabilities/WstETHHookRounding.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+
+import {WstETHHookHarness} from "../harness/WstETHHookHarness.sol";
+import {MockWstETH} from "../mocks/MockWstETH.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+import {TestRouter} from "../shared/TestRouter.sol";
+import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+
+contract WstETHHookRoundingTest is Test, Deployers {
+    WstETHHookHarness hook;
+    MockWstETH wstETH;
+    MockERC20 stETH;
+    TestRouter router;
+    PoolKey poolKey;
+    uint160 initPrice;
+    address alice = makeAddr("alice");
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        router = new TestRouter(manager);
+        stETH = new MockERC20("stETH", "STETH", 18);
+        wstETH = new MockWstETH(address(stETH));
+        hook = WstETHHookHarness(
+            payable(
+                address(
+                    uint160(
+                        type(uint160).max & clearAllHookPermissionsMask | Hooks.BEFORE_SWAP_FLAG
+                            | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG
+                            | Hooks.BEFORE_INITIALIZE_FLAG
+                    )
+                )
+            )
+        );
+        deployCodeTo("WstETHHookHarness", abi.encode(manager, wstETH), address(hook));
+        poolKey = PoolKey({
+            currency0: Currency.wrap(address(stETH)),
+            currency1: Currency.wrap(address(wstETH)),
+            fee: 0,
+            tickSpacing: 60,
+            hooks: IHooks(address(hook))
+        });
+        initPrice = uint160(TickMath.getSqrtPriceAtTick(0));
+        manager.initialize(poolKey, initPrice);
+        stETH.mint(alice, 1); // 1 wei
+    }
+
+    function test_rounding_wrap_zero_out() public {
+        vm.startPrank(alice);
+        stETH.approve(address(router), 1);
+        router.swap(
+            poolKey,
+            SwapParams({zeroForOne: true, amountSpecified: -int256(1), sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1}),
+            ""
+        );
+        vm.stopPrank();
+        assertEq(stETH.balanceOf(alice), 0);
+        assertEq(wstETH.balanceOf(alice), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add regression tests for reinitialization bug
- add test demonstrating forced ETH injection via `selfdestruct`
- add rounding test for wstETH hook

## Testing
- `forge test -vvv`
- `forge snapshot`


------
https://chatgpt.com/codex/tasks/task_e_68673babfb88832d998e7bde48915f82