### PR TITLE
Add remaining vulnerability tests

### DIFF
--- a/test/mocks/GasGriefSubscriber.sol
+++ b/test/mocks/GasGriefSubscriber.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.8.24;
+
+import {ISubscriber} from "../../src/interfaces/ISubscriber.sol";
+import {PositionInfo} from "../../src/libraries/PositionInfoLibrary.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+
+/// @notice Subscriber that consumes all gas in notifyUnsubscribe
+contract GasGriefSubscriber is ISubscriber {
+    function notifySubscribe(uint256, bytes memory) external {}
+
+    function notifyUnsubscribe(uint256) external {
+        while (true) {}
+    }
+
+    function notifyBurn(uint256 tokenId, address owner, PositionInfo info, uint256 liquidity, BalanceDelta fees)
+        external
+    {}
+
+    function notifyModifyLiquidity(uint256, int256, BalanceDelta) external {}
+}

--- a/test/mocks/MalSubscriber.sol
+++ b/test/mocks/MalSubscriber.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.8.24;
+
+import {ISubscriber} from "../../src/interfaces/ISubscriber.sol";
+import {PositionInfo} from "../../src/libraries/PositionInfoLibrary.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {MockBaseActionsRouter} from "./MockBaseActionsRouter.sol";
+
+contract MalSubscriber is ISubscriber {
+    MockBaseActionsRouter router;
+    bytes data;
+
+    constructor(MockBaseActionsRouter _router, bytes memory _data) {
+        router = _router;
+        data = _data;
+    }
+
+    function notifySubscribe(uint256, bytes memory) external {}
+    function notifyUnsubscribe(uint256) external {}
+    function notifyBurn(uint256 tokenId, address owner, PositionInfo info, uint256 liquidity, BalanceDelta fees)
+        external
+    {}
+
+    function notifyModifyLiquidity(uint256, int256, BalanceDelta) external {
+        router.executeActions(data);
+    }
+}

--- a/test/mocks/MockPoolManagerUnlock.sol
+++ b/test/mocks/MockPoolManagerUnlock.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.8.24;
+
+import {ISubscriber} from "../../src/interfaces/ISubscriber.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+
+contract MockPoolManagerUnlock {
+    bool public unlocked;
+    ISubscriber public subscriber;
+
+    function setSubscriber(ISubscriber sub) external {
+        subscriber = sub;
+    }
+
+    function unlock(bytes calldata data) external returns (bytes memory) {
+        require(!unlocked, "already unlocked");
+        unlocked = true;
+        if (address(subscriber) != address(0)) {
+            subscriber.notifyModifyLiquidity(0, 0, BalanceDelta.wrap(0));
+        }
+        (bool ok, bytes memory ret) = msg.sender.call(abi.encodeWithSignature("unlockCallback(bytes)", data));
+        unlocked = false;
+        require(ok, "callback fail");
+        return ret;
+    }
+}

--- a/test/mocks/MockVariableWstETH.sol
+++ b/test/mocks/MockVariableWstETH.sol
@@ -1,0 +1,56 @@
+pragma solidity ^0.8.24;
+
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+import {IWstETH} from "../../src/interfaces/external/IWstETH.sol";
+
+/// @title Mock Variable Rate Wrapped Staked ETH
+/// @notice wstETH mock with adjustable exchange rate for testing
+contract MockVariableWstETH is MockERC20, IWstETH {
+    address public immutable stETHToken;
+    uint256 public exchangeRate; // stETH per wstETH with 18 decimals
+
+    constructor(address _stETH, uint256 _rate) MockERC20("Wrapped Staked ETH", "wstETH", 18) {
+        stETHToken = _stETH;
+        exchangeRate = _rate;
+    }
+
+    function setExchangeRate(uint256 _rate) external {
+        exchangeRate = _rate;
+    }
+
+    function wrap(uint256 _stETHAmount) external returns (uint256) {
+        MockERC20(stETHToken).transferFrom(msg.sender, address(this), _stETHAmount);
+        uint256 wstAmount = getWstETHByStETH(_stETHAmount);
+        _mint(msg.sender, wstAmount);
+        return wstAmount;
+    }
+
+    function unwrap(uint256 _wstETHAmount) external returns (uint256) {
+        _burn(msg.sender, _wstETHAmount);
+        uint256 stAmount = getStETHByWstETH(_wstETHAmount);
+        MockERC20(stETHToken).transfer(msg.sender, stAmount);
+        return stAmount;
+    }
+
+    function getWstETHByStETH(uint256 _stETHAmount) public view returns (uint256) {
+        if (_stETHAmount == 0) return 0;
+        return (_stETHAmount * 1e18) / exchangeRate;
+    }
+
+    function getStETHByWstETH(uint256 _wstETHAmount) public view returns (uint256) {
+        if (_wstETHAmount == 0) return 0;
+        return (_wstETHAmount * exchangeRate) / 1e18;
+    }
+
+    function stEthPerToken() external view returns (uint256) {
+        return exchangeRate;
+    }
+
+    function tokensPerStEth() external view returns (uint256) {
+        return 1e36 / exchangeRate;
+    }
+
+    function stETH() external view returns (address) {
+        return stETHToken;
+    }
+}

--- a/test/vulnerabilities/NotifierGasGrief.t.sol
+++ b/test/vulnerabilities/NotifierGasGrief.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {NotifierHarness} from "../mocks/NotifierHarness.sol";
+import {GasGriefSubscriber} from "../mocks/GasGriefSubscriber.sol";
+import {INotifier} from "../../src/interfaces/INotifier.sol";
+
+contract NotifierGasGriefTest is Test {
+    NotifierHarness notifier;
+    GasGriefSubscriber sub;
+
+    function setUp() public {
+        notifier = new NotifierHarness(100000);
+        sub = new GasGriefSubscriber();
+        notifier.subscribe(1, address(sub), "");
+    }
+
+    function test_unsubscribe_gas_grief() public {
+        uint256 gasLimit = notifier.unsubscribeGasLimit();
+        vm.expectRevert();
+        notifier.unsubscribeWrap{gas: gasLimit - 1}(1);
+        assertEq(address(notifier.subscriber(1)), address(sub));
+    }
+}

--- a/test/vulnerabilities/ReentrantUnlock.t.sol
+++ b/test/vulnerabilities/ReentrantUnlock.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {Planner} from "../shared/Planner.sol";
+import {Actions} from "../../src/libraries/Actions.sol";
+import {ReentrancyLock} from "../../src/base/ReentrancyLock.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+
+import {MockPoolManagerUnlock} from "../mocks/MockPoolManagerUnlock.sol";
+import {MockBaseActionsRouter} from "../mocks/MockBaseActionsRouter.sol";
+import {MalSubscriber} from "../mocks/MalSubscriber.sol";
+
+contract ReentrantUnlockTest is Test {
+    MockPoolManagerUnlock manager;
+    MockBaseActionsRouter router;
+
+    function setUp() public {
+        manager = new MockPoolManagerUnlock();
+        router = new MockBaseActionsRouter(IPoolManager(address(manager)));
+    }
+
+    function test_reentrant_unlock_reverts() public {
+        bytes memory plan = Planner.init().add(Actions.DONATE, "").encode();
+        MalSubscriber mal = new MalSubscriber(router, plan);
+        manager.setSubscriber(mal);
+
+        vm.expectRevert(abi.encodeWithSelector(ReentrancyLock.ContractLocked.selector));
+        router.executeActions(plan);
+    }
+}

--- a/test/vulnerabilities/WstETHHookFlashLoanRate.t.sol
+++ b/test/vulnerabilities/WstETHHookFlashLoanRate.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+
+import {WstETHHookHarness} from "../harness/WstETHHookHarness.sol";
+import {MockVariableWstETH} from "../mocks/MockVariableWstETH.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+import {TestRouter} from "../shared/TestRouter.sol";
+import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+
+contract WstETHHookFlashLoanRateTest is Test, Deployers {
+    WstETHHookHarness hook;
+    MockVariableWstETH wstETH;
+    MockERC20 stETH;
+    TestRouter router;
+    PoolKey poolKey;
+    uint160 initPrice;
+    address alice = makeAddr("alice");
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        router = new TestRouter(manager);
+        stETH = new MockERC20("stETH", "STETH", 18);
+        wstETH = new MockVariableWstETH(address(stETH), 11e17);
+        hook = WstETHHookHarness(
+            payable(
+                address(
+                    uint160(
+                        type(uint160).max & clearAllHookPermissionsMask | Hooks.BEFORE_SWAP_FLAG
+                            | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG
+                            | Hooks.BEFORE_INITIALIZE_FLAG
+                    )
+                )
+            )
+        );
+        deployCodeTo("WstETHHookHarness", abi.encode(manager, wstETH), address(hook));
+        poolKey = PoolKey({
+            currency0: Currency.wrap(address(stETH)),
+            currency1: Currency.wrap(address(wstETH)),
+            fee: 0,
+            tickSpacing: 60,
+            hooks: IHooks(address(hook))
+        });
+        initPrice = uint160(TickMath.getSqrtPriceAtTick(0));
+        manager.initialize(poolKey, initPrice);
+        stETH.mint(alice, 1 ether);
+    }
+
+    function test_flash_loan_rate_manipulation() public {
+        wstETH.setExchangeRate(22e17); // rate doubles before swap
+
+        vm.startPrank(alice);
+        stETH.approve(address(router), 1 ether);
+        router.swap(
+            poolKey,
+            SwapParams({
+                zeroForOne: true,
+                amountSpecified: -int256(1 ether),
+                sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1
+            }),
+            ""
+        );
+        vm.stopPrank();
+
+        assertLt(wstETH.balanceOf(alice), 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary
- implement additional vulnerability tests for gas griefing, reentrant unlocks, and flash loan rate manipulation
- add supporting mocks for variable wstETH, malicious subscriber, and pool manager harness

## Testing
- `forge test`
- `forge snapshot`


------
https://chatgpt.com/codex/tasks/task_e_68675b93d27c832d8af51c867946e612