### PR TITLE
Add failing tests for Descriptor escaping bug

### DIFF
--- a/test/libraries/Descriptor.t.sol
+++ b/test/libraries/Descriptor.t.sol
@@ -55,6 +55,14 @@ contract DescriptorTest is Test {
         assertEq(Descriptor.escapeSpecialCharacters("a\u000cbc"), "a\\\u000cbc");
     }
 
+    function test_escapeSpecialCharacters_backslash_expectedEscape() public pure {
+        assertEq(Descriptor.escapeSpecialCharacters("a\\bc"), "a\\\\bc");
+    }
+
+    function test_escapeSpecialCharacters_forwardSlash_expectedEscape() public pure {
+        assertEq(Descriptor.escapeSpecialCharacters("a/bc"), "a\\/bc");
+    }
+
     function test_tickToDecimalString_withTickSpacing10() public pure {
         int24 tickSpacing = 10;
         int24 minTick = (TickMath.MIN_TICK / tickSpacing) * tickSpacing;


### PR DESCRIPTION
## Summary
- add tests that expect backslash and forward slash to be escaped in `escapeSpecialCharacters`

## Testing
- `forge test -vvv`


------
https://chatgpt.com/codex/tasks/task_e_687a9c030754832da6f7ba1e6dc44ad6